### PR TITLE
Add `TabbedPanel.vue` component for local tab switching

### DIFF
--- a/app/frontend/components/common/tabs/TabbedPanel.vue
+++ b/app/frontend/components/common/tabs/TabbedPanel.vue
@@ -1,0 +1,41 @@
+<script setup>
+const props = defineProps({
+  tabs: { type: Array, required: true }, // [{ id: 'profile', label: 'Profile' }]
+  modelValue: String
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+function select(tabId) {
+  emit('update:modelValue', tabId)
+}
+</script>
+
+<template>
+  <nav role="tablist" class="bg-white-transp-1000 flex gap-3 overflow-x-auto no-scroll-bar py-3">
+    <button
+      v-for="(tab, index) in props.tabs"
+      :key="tab.id"
+      @click="select(tab.id)"
+      class="p-0"
+    >
+      <!-- Border gradient wrapper -->
+      <div
+        :class="[
+          'pb-[2px]',
+          modelValue === tab.id
+            ? 'bg-gradient-to-r from-magenta-600 to-laranja-600'
+            : 'bg-neutrals-200'
+        ]"
+      >
+        <!-- Inner tab content -->
+        <div
+          class="bg-white px-[33.3px] pt-[6px] text-body-strong-sm flex items-center justify-center"
+          :class="modelValue === tab.id ? 'text-neutrals-900' : 'text-neutrals-700'"
+        >
+          {{ tab.label }}
+        </div>
+      </div>
+    </button>
+  </nav>
+</template>


### PR DESCRIPTION
This PR introduces a new reusable `TabbedPanel.vue` component used to handle **single-page tab switching** without navigation.

#### ✅ Features
- Styled to match existing tab component with **gradient bottom border** on active tab
- Uses `v-model` to bind the active tab state
- Fully customizable via props
- Works with both mobile (tabs) and desktop (columns) layouts

---

### 🧩 Usage

```vue
<script setup>
import TabbedPanel from "@/components/common/tabs/TabbedPanel.vue"
import { ref } from 'vue'

const activeTab = ref('profile')

const tabs = [
  { id: 'profile', label: 'Profile' },
  { id: 'settings', label: 'Settings' },
  { id: 'stats', label: 'Stats' }
]
</script>

<template>
  <TabbedPanel v-model="activeTab" :tabs="tabs" class="justify-center" />

  <div class="flex flex-col gap-6 sm:flex-row sm:gap-4">
    <section v-show="activeTab === 'profile' || isDesktop" class="w-full sm:w-1/3">
      FLAMENGO
    </section>
    <section v-show="activeTab === 'settings' || isDesktop" class="w-full sm:w-1/3">
      OCTA
    </section>
    <section v-show="activeTab === 'stats' || isDesktop" class="w-full sm:w-1/3">
      CAMPEAO
    </section>
  </div>
</template>
```

#### 🛠 Props
| Prop             | Type            | Description                         |
| ------------- | ------------- | ----------------------------- |
| tabs             | Array            | List of { id, label } tab         |
| modelValue | String           | The currently active tab id |

This component is useful for scenarios where we want to toggle content within the same page, like tabbed views or mobile-friendly sections.
