### PR TITLE
Refac/pelicula show

### DIFF
--- a/app/controllers/peliculas_controller.rb
+++ b/app/controllers/peliculas_controller.rb
@@ -2,7 +2,7 @@ class PeliculasController < ApplicationController
   include BreadcrumbsHelper
 
   def show
-    @pelicula = Pelicula.find_by(edicao_id: 12, permalink: params[:permalink])
+    @pelicula = Pelicula.includes(:paises, :mostra, programacoes: :cinema).find_by(edicao_id: 12, permalink: params[:permalink])
     render inertia: "Peliculas/Show", props: {
       rootUrl: @root_url,
       pelicula: @pelicula.as_json(

--- a/app/frontend/components/common/cards/PeliculaCreditoCard.vue
+++ b/app/frontend/components/common/cards/PeliculaCreditoCard.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { computed } from 'vue';
+const props = defineProps({
+  header: { type: String, default: "direção"},
+  pelicula: { type: Object, required: true }
+})
+
+// TODO: Think about sending it
+// from controller in order
+// to trasnlate keys. Those are used
+// to display the team name in the view
+const teams = computed(() => {
+  return { roteiro: props.pelicula.roteiro_team,
+    "direção": props.pelicula.diretor_team,
+    fotografia: props.pelicula.fotografia_team,
+    "Produção Empresa": props.pelicula.producaoempresa_team,
+    montagem: props.pelicula.montagem_team
+  }
+})
+
+console.log(props.pelicula);
+
+</script>
+
+<template>
+  <div class="credito__card">
+    <div class="py-600 md:pt-0">
+      <h3 class="text-overline text-neutrals-700 uppercase pb-300">{{ header }}</h3>
+      <!-- TODO: TRANSLATE -->
+      <div class="card__director rounded-200 w-1/2">
+        <img
+          :src="pelicula.director_image"
+          :alt="`Foto de ${pelicula.diretor_coord_int}`"
+          class="h-[154px] w-full object-cover object-top rounded-t-200"
+          loading="lazy"
+        >
+        <div class="card__content bg-neutrals-200 rounded-200 ps-200 py-250">
+          <p class="text-header-md text-neutrals-900">{{ pelicula.diretor_coord_int }}</p>
+        </div>
+      </div>
+    </div>
+    <hr class="text-neutrals-300">
+    <div class="space-y-400 pt-400">
+      <!-- { roteiro: [], fotografia: [], montagem: [],  direção: [], producaoempresa: []} -->
+      <div class="grid grid-cols-3" v-for="([name, members]) in Object.entries(teams)">
+        <p class="text-overline text-neutrals-700 uppercase pb-200">{{ name }}</p>
+        <ul class="col-span-2 flex flex-col">
+          <li v-for="member in members" :key="member">
+            <p class="text-body-regular">{{ member }}</p>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/app/frontend/components/common/cards/PeliculaCreditoCard.vue
+++ b/app/frontend/components/common/cards/PeliculaCreditoCard.vue
@@ -24,10 +24,10 @@ console.log(props.pelicula);
 
 <template>
   <div class="credito__card">
-    <div class="py-600 md:pt-0">
+    <div class="pb-600">
       <h3 class="text-overline text-neutrals-700 uppercase pb-300">{{ header }}</h3>
       <!-- TODO: TRANSLATE -->
-      <div class="card__director rounded-200 w-1/2">
+      <div class="card__director rounded-200 w-1/2 sm:w-1/3">
         <img
           :src="pelicula.director_image"
           :alt="`Foto de ${pelicula.diretor_coord_int}`"
@@ -42,7 +42,7 @@ console.log(props.pelicula);
     <hr class="text-neutrals-300">
     <div class="space-y-400 pt-400">
       <!-- { roteiro: [], fotografia: [], montagem: [],  direção: [], producaoempresa: []} -->
-      <div class="grid grid-cols-3" v-for="([name, members]) in Object.entries(teams)">
+      <div class="grid grid-cols-4" v-for="([name, members]) in Object.entries(teams)">
         <p class="text-overline text-neutrals-700 uppercase pb-200">{{ name }}</p>
         <ul class="col-span-2 flex flex-col">
           <li v-for="member in members" :key="member">

--- a/app/frontend/components/common/cards/PeliculaPosterCard.vue
+++ b/app/frontend/components/common/cards/PeliculaPosterCard.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 <template>
   <div class="flex flex-col gap-400 py-400 items-center justify-center">
     <img
-      :src="props.pelicula.imageURL"
+      :src="props.pelicula.posterImageURL"
       class="h-[251px] w-[201px] object-cover"
       :alt="`${props.pelicula.display_titulo} banner`"
       loading="lazy"

--- a/app/frontend/components/common/cards/PeliculaPosterCard.vue
+++ b/app/frontend/components/common/cards/PeliculaPosterCard.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div class="flex flex-col gap-400 py-400 items-center justify-center">
+  <div class="flex flex-col gap-400 items-center justify-center">
     <img
       :src="props.pelicula.posterImageURL"
       class="h-[251px] w-[201px] object-cover"

--- a/app/frontend/components/common/cards/PeliculaPosterCard.vue
+++ b/app/frontend/components/common/cards/PeliculaPosterCard.vue
@@ -1,0 +1,27 @@
+<script setup>
+import IconChevronRight from '@/components/common/icons/navigation/IconChevronRight.vue';
+import ButtonText from '@/components/common/buttons/ButtonText.vue';
+
+const props = defineProps({
+  pelicula: { type: Object, required: true }
+})
+</script>
+
+<template>
+  <div class="flex flex-col gap-400 py-400 items-center justify-center">
+    <img
+      :src="props.pelicula.imageURL"
+      class="h-[251px] w-[201px] object-cover"
+      :alt="`${props.pelicula.display_titulo} banner`"
+      loading="lazy"
+    >
+    <!-- TRanslate website -->
+    <ButtonText variant="dark" class="gap-200" text="Ver fotos de imprensa" tag="a">
+      <template #icon>
+        <IconChevronRight height="16" width="16" color="inherit order-2"/>
+      </template>
+    </ButtonText>
+  </div>
+</template>
+
+<style scoped></style>

--- a/app/frontend/components/common/cards/PeliculaSessionCard.vue
+++ b/app/frontend/components/common/cards/PeliculaSessionCard.vue
@@ -1,18 +1,23 @@
 <script setup>
-// TODO: ADD PROPS AND EVERYTHING
 import { BaseButton } from '@/components/common/buttons';
 import { IconPin } from '@/components/common/icons';
 import TagScreening from '@/components/common/tags/TagScreening.vue';
+
+const props = defineProps({
+  session: { type: Object, required: true}
+})
+
+// TODO: date display
 </script>
 
 <template>
   <div class="bg-neutrals-200 p-400 flex flex-col gap-400 rounded-200">
-    <h3 class="text-header-medium-sm">Qua, 9 Set</h3>
+    <h3 class="text-header-medium-sm">{{ props.session.data}}</h3>
     <div>
       <div class="flex items-center gap-200 pb-100">
-        <IconPin height="16" width="16" color="text-neutrals-900"/> <p class="text-body-regular-line-small">Cine Odeon - CCLSR</p>
+        <IconPin height="16" width="16" color="text-neutrals-900"/> <p class="text-body-regular-line-small"> {{ props.session.cinema_name }}</p>
       </div>
-      <p class="text-body-regular-xs">Praça Floriano, 7 - Centro</p>
+      <p class="text-body-regular-xs">{{ props.session.cinema_address }}</p>
     </div>
     <div class="flex items-center gap-200">
       <img src="@/assets/icons/icon_info.svg" alt="Ícone de informação">

--- a/app/frontend/components/common/cards/PeliculaSessionCard.vue
+++ b/app/frontend/components/common/cards/PeliculaSessionCard.vue
@@ -4,14 +4,14 @@ import { IconPin } from '@/components/common/icons';
 import TagScreening from '@/components/common/tags/TagScreening.vue';
 
 const props = defineProps({
-  session: { type: Object, required: true}
+  session: { type: Object, required: true }
 })
 
 // TODO: date display
 </script>
 
 <template>
-  <div class="bg-neutrals-200 p-400 flex flex-col gap-400 rounded-200">
+  <div class="bg-neutrals-200 p-400 flex flex-col gap-400 rounded-200 mb-400">
     <h3 class="text-header-medium-sm">{{ props.session.data}}</h3>
     <div>
       <div class="flex items-center gap-200 pb-100">
@@ -23,7 +23,7 @@ const props = defineProps({
       <img src="@/assets/icons/icon_info.svg" alt="Ícone de informação">
       <p class="font-body text-xs leading-[140%] font-regular italic">Venda de ingressos limitada</p>
     </div>
-    <TagScreening state="default" time="21h15"/>
+    <TagScreening state="default" :time="props.session.sessao"/>
     <BaseButton size="sm" class="border-neutrals-900 border-2">Comprar ingressos</BaseButton>
   </div>
 </template>

--- a/app/frontend/components/common/icons/navigation/IconChevronLeft.vue
+++ b/app/frontend/components/common/icons/navigation/IconChevronLeft.vue
@@ -2,7 +2,7 @@
 import { BaseIcon } from "@components/common/icons"
 
 const props = defineProps({
-  color: { type: String, default: undefined },
+  color: { type: String, default: 'inherit' },
   active: { type: Boolean, default: false },
   width: { type: String, default: "20" },
   height: { type: String, default: "20" }

--- a/app/frontend/components/common/icons/navigation/IconChevronRight.vue
+++ b/app/frontend/components/common/icons/navigation/IconChevronRight.vue
@@ -2,7 +2,7 @@
 import { BaseIcon } from "@components/common/icons"
 
 const props = defineProps({
-  color: { type: String, default: undefined },
+  color: { type: String, default: 'inherit' },
   active: { type: Boolean, default: false },
   width: { type: String, default: "20" },
   height: { type: String, default: "20" }

--- a/app/frontend/components/common/tabs/TabbedPanel.vue
+++ b/app/frontend/components/common/tabs/TabbedPanel.vue
@@ -13,29 +13,32 @@ function select(tabId) {
 
 <template>
   <nav role="tablist" class="bg-white-transp-1000 flex gap-300 overflow-x-auto no-scroll-bar py-3">
-    <button
-      v-for="(tab, index) in props.tabs"
-      :key="tab.id"
-      @click="select(tab.id)"
-      class="p-0"
-    >
-      <!-- Border gradient wrapper -->
-      <div
-        :class="[
-          'pb-[2px]',
-          modelValue === tab.id
-            ? 'bg-gradient-to-r from-magenta-600 to-laranja-600'
-            : 'bg-neutrals-200'
-        ]"
+    <div class="w-full flex items-center justify-around md:justify-evenly">
+      <button
+        v-for="(tab, index) in props.tabs"
+        :key="tab.id"
+        @click="select(tab.id)"
+        class="p-0"
       >
-        <!-- Inner tab content -->
+        <!-- Border gradient wrapper -->
         <div
-          class="bg-white px-[7.3px] lg:px-[33.3px] pt-[6px] flex items-center justify-center text-body-strong-sm uppercase"
-          :class="modelValue === tab.id ? 'text-neutrals-900' : 'text-neutrals-700'"
+          :class="[
+            'pb-[2px]',
+            modelValue === tab.id
+              ? 'bg-gradient-to-r from-magenta-600 to-laranja-600'
+              : 'bg-neutrals-200'
+          ]"
         >
-          {{ tab.label }}
+          <!-- Inner tab content -->
+          <div
+            class="bg-white px-[7.3px] lg:px-[33.3px] pt-[6px] flex items-center justify-center text-body-strong-sm uppercase"
+            :class="modelValue === tab.id ? 'text-neutrals-900' : 'text-neutrals-700'"
+          >
+            {{ tab.label }}
+          </div>
         </div>
-      </div>
-    </button>
+      </button>
+
+    </div>
   </nav>
 </template>

--- a/app/frontend/components/features/peliculas/CreditosContent.vue
+++ b/app/frontend/components/features/peliculas/CreditosContent.vue
@@ -1,91 +1,28 @@
 <script setup>
+import { useUpdateWindowWidth } from '@/lib/utils';
+import { defineAsyncComponent } from 'vue';
+
+const PeliculaCreditoCard = defineAsyncComponent(() => import('@/components/common/cards/PeliculaCreditoCard.vue'));
+const PeliculaPosterCard = defineAsyncComponent(() => import('@/components/common/cards/PeliculaPosterCard.vue'));
+
 const props = defineProps({
-  director_image: { type: String, required: true },
-  diretor_coord_int: { type: String, required: true },
-  diretor_coord_int: { type: String, required: true },
-  roteiro_team: { type: Array, required: true },
-  fotografia_team: { type: Array, required: true },
-  montagem_team: { type: Array, required: true },
-  diretor_team: { type: Array, required: true },
-  producaoempresa_team: { type: Array, required: true },
+  pelicula: { type: Object, required: true}
 })
+
+const isDesktop = useUpdateWindowWidth()
+console.log(isDesktop.value);
 
 </script>
 
 <template>
-  <div class="py-600 md:pt-0">
-    <h3 class="text-overline text-neutrals-700 uppercase pb-300">DIREÇÃO</h3>
-    <!-- TODO: TRANSLATE -->
-    <div class="card__director rounded-200 w-1/2">
-      <img
-        :src="props.director_image"
-        :alt="`Foto de ${props.diretor_coord_int}`"
-        class="h-[154px] w-full object-cover object-top rounded-t-200"
-        loading="lazy"
-      >
-      <div class="card__content bg-neutrals-200 rounded-200 ps-200 py-250">
-        <p class="text-header-md text-neutrals-900">{{ props.diretor_coord_int }}</p>
-      </div>
-    </div>
+  <div v-if="isDesktop">
+    <PeliculaPosterCard :pelicula="props.pelicula" />
   </div>
-  <hr class="text-neutrals-300">
-  <div class="space-y-400 pt-400">
-    <div class="grid grid-cols-3">
-      <p class="text-overline text-neutrals-700 uppercase pb-200">roteiro</p>
-      <ul class="col-span-2 flex flex-col">
-        <li
-          v-for="member in props.roteiro_team"
-          :key="member"
-        >
-          <p class="text-body-regular">{{ member }}</p>
-        </li>
-      </ul>
-    </div>
-    <div class="grid grid-cols-3">
-      <p class="text-overline text-neutrals-700 uppercase pb-200">fotografia</p>
-      <ul class="col-span-2 flex flex-col">
-        <li
-          v-for="member in props.fotografia_team"
-          :key="member"
-        >
-          <p class="text-body-regular">{{ member }}</p>
-        </li>
-      </ul>
-    </div>
-    <div class="grid grid-cols-3">
-      <p class="text-overline text-neutrals-700 uppercase pb-200">montagem</p>
-      <ul class="col-span-2 flex flex-col">
-        <li
-          v-for="member in props.montagem_team"
-          :key="member"
-        >
-          <p class="text-body-regular">{{ member }}</p>
-        </li>
-      </ul>
-    </div>
-    <div class="grid grid-cols-3">
-      <p class="text-overline text-neutrals-700 uppercase pb-200">direção</p>
-      <ul class="col-span-2 flex flex-col">
-        <li
-          v-for="member in props.diretor_team"
-          :key="member"
-        >
-          <p class="text-body-regular">{{ member }}</p>
-        </li>
-      </ul>
-    </div>
-    <div class="grid grid-cols-3">
-      <p class="text-overline text-neutrals-700 uppercase pb-200">direção</p>
-      <ul class="col-span-2 flex flex-col">
-        <li
-          v-for="member in props.producaoempresa_team"
-          :key="member"
-        >
-          <p class="text-body-regular text-neutrals-900">{{ member }}</p>
-        </li>
-      </ul>
-    </div>
-
+  <div v-else>
+    <PeliculaCreditoCard
+      header="direção"
+      :pelicula="props.pelicula"
+    />
   </div>
 </template>
 

--- a/app/frontend/components/features/peliculas/InformacoesContent.vue
+++ b/app/frontend/components/features/peliculas/InformacoesContent.vue
@@ -13,9 +13,14 @@ const isDesktop =  useUpdateWindowWidth()
 </script>
 
 <template>
-  <div>
-    <h3 class="text-overline text-neutrals-700 uppercase pb-200">sobre o filme</h3>
-    <p class="text-body-regular text-neutrals-900">{{ props.pelicula.display_sinopse }}</p>
+  <div class="space-y-600">
+    <div class="">
+      <h3 class="text-overline text-neutrals-700 uppercase pb-200">sobre o filme</h3>
+      <p class="text-body-regular text-neutrals-900">{{ props.pelicula.display_sinopse }}</p>
+    </div>
+
+    <hr class="text-neutrals-300">
+
     <div v-if="isDesktop">
       <!-- desktop display policula creditos -->
       <PeliculaCreditoCard
@@ -27,6 +32,8 @@ const isDesktop =  useUpdateWindowWidth()
     <div v-else>
       <PeliculaPosterCard :pelicula="props.pelicula" />
     </div>
+
+    <hr class="text-neutrals-300">
 
     <div :class="`border-s-8 border-${props.pelicula.mostra_tag_class} rounded-100 px-400 py-300 flex flex-col gap-200 col-span-2 h-fit`">
       <h2 class="text-header-medium-sm text-neutrals-900">{{ props.pelicula.mostra_name }}</h2>

--- a/app/frontend/components/features/peliculas/InformacoesContent.vue
+++ b/app/frontend/components/features/peliculas/InformacoesContent.vue
@@ -1,45 +1,42 @@
 <script setup>
 import { defineAsyncComponent } from 'vue';
-
-import IconChevronRight from '@/components/common/icons/navigation/IconChevronRight.vue';
-import ButtonText from '@/components/common/buttons/ButtonText.vue';
+import PeliculaCreditoCard from '@/components/common/cards/PeliculaCreditoCard.vue';
+import PeliculaPosterCard from '@/components/common/cards/PeliculaPosterCard.vue';
 const CarouselComponent = defineAsyncComponent(() => import('@/components/ui/CarouselComponent.vue'));
 
+import { useUpdateWindowWidth } from '@/lib/utils';
+
 const props = defineProps({
-  display_sinopse: String,
-  imageURL: String,
-  display_titulo: String,
-  mostra_tag_class: String,
-  mostra_name: String,
-  carousel_images: Array,
+  pelicula: { type: Object, required: true },
 })
+const isDesktop =  useUpdateWindowWidth()
 </script>
 
 <template>
   <div>
     <h3 class="text-overline text-neutrals-700 uppercase pb-200">sobre o filme</h3>
-    <p class="text-body-regular text-neutrals-900">{{ props.display_sinopse }}</p>
-    <div class="flex flex-col gap-400 py-400 items-center justify-center">
-      <img
-        :src="props.imageURL"
-        class="h-[251px] w-[201px] object-cover"
-        :alt="`${props.display_titulo} banner`"
-        loading="lazy"
-      >
-      <!-- TRanslate website -->
-      <ButtonText variant="dark" class="gap-200" text="Ver fotos de imprensa" tag="a">
-        <template #icon>
-          <IconChevronRight height="16" width="16" color="inherit order-2"/>
-        </template>
-      </ButtonText>
+    <p class="text-body-regular text-neutrals-900">{{ props.pelicula.display_sinopse }}</p>
+    <div v-if="isDesktop">
+      <!-- desktop display policula creditos -->
+      <PeliculaCreditoCard
+        header="direção"
+        :pelicula="props.pelicula"
+      />
     </div>
-    <div :class="`border-s-8 border-${props.mostra_tag_class} rounded-100 px-400 py-300 flex flex-col gap-200 col-span-2 h-fit`">
-      <h2 class="text-header-medium-sm text-neutrals-900">{{ props.mostra_name }}</h2>
+    <!-- mobile display pelicula poster -->
+    <div v-else>
+      <PeliculaPosterCard :pelicula="props.pelicula" />
+    </div>
+
+    <div :class="`border-s-8 border-${props.pelicula.mostra_tag_class} rounded-100 px-400 py-300 flex flex-col gap-200 col-span-2 h-fit`">
+      <h2 class="text-header-medium-sm text-neutrals-900">{{ props.pelicula.mostra_name }}</h2>
+      <!-- todo: mostra description?? -->
       <p class="text-body-regular text-neutrals-900">A Première Brasil é a mostra competitiva central do Festival do Rio, dedicada a filmes brasileiros inéditos que valorizam a diversidade de narrativas e refletem a realidade do país. Desde 1999, já apresentou mais de 1.300 títulos. Curtas e longas selecionados integram mostras competitivas e não competitivas, com as produções em disputa concorrendo ao Troféu Redentor na seleção principal ou na Première Brasil: Novos Rumos.</p>
     </div>
 
+    <div></div>
     <Suspense>
-      <CarouselComponent :imageCollection="props.carousel_images" :class-names="['pt-800']" />
+      <CarouselComponent v-if="!isDesktop" :imageCollection="props.pelicula.carousel_images" :class-names="['pt-800']" />
       <template #fallback>
         <div class="h-48 bg-gray-200 animate-pulse rounded pt-800"></div>
       </template>

--- a/app/frontend/components/features/peliculas/SessoesContent.vue
+++ b/app/frontend/components/features/peliculas/SessoesContent.vue
@@ -1,14 +1,16 @@
 <script setup>
 import { defineAsyncComponent } from 'vue';
 import BaseButton from '@/components/common/buttons/BaseButton.vue';
-const PeliculaSession = defineAsyncComponent(() => import('@/components/common/cards/PeliculaSessionCard.vue'));
+const PeliculaSessionCard = defineAsyncComponent(() => import('@/components/common/cards/PeliculaSessionCard.vue'));
+const props = defineProps({
+  sessions: { type: Array, default: () => [] }
+})
 </script>
 <!-- TODO: TRADUZIR -->
 <template>
   <BaseButton variant="dark" class="w-full">Comprar pacote de ingressos</BaseButton>
-
-  <div v-for="(item, index) in [1,2,3]">
-    <PeliculaSession class="mb-400" />
+  <div v-for="(session, index) in props.sessions">
+    <PeliculaSessionCard class="mb-400" :session="session" />
     <hr v-show="index < 2" class="text-neutrals-300">
   </div>
 </template>

--- a/app/frontend/components/features/peliculas/SessoesContent.vue
+++ b/app/frontend/components/features/peliculas/SessoesContent.vue
@@ -1,17 +1,55 @@
 <script setup>
-import { defineAsyncComponent } from 'vue';
+import { defineAsyncComponent, ref } from 'vue';
 import BaseButton from '@/components/common/buttons/BaseButton.vue';
+import { IconChevronLeft, IconChevronRight } from '@/components/common/icons';
 const PeliculaSessionCard = defineAsyncComponent(() => import('@/components/common/cards/PeliculaSessionCard.vue'));
 const props = defineProps({
   sessions: { type: Array, default: () => [] }
 })
+
+const pagesTotal = props.sessions.length;
+const activePage = ref(0);
+
+const sessionWrapper = ref(null);
+
+function scrollToTopOfSessions() {
+  sessionWrapper.value?.scrollIntoView({ behavior: 'smooth' });
+}
+
+console.log(props.sessions)
 </script>
 <!-- TODO: TRADUZIR -->
 <template>
-  <BaseButton variant="dark" class="w-full">Comprar pacote de ingressos</BaseButton>
-  <div v-for="(session, index) in props.sessions">
-    <PeliculaSessionCard class="mb-400" :session="session" />
-    <hr v-show="index < 2" class="text-neutrals-300">
+  <div ref="sessionWrapper" class="flex flex-col gap-400">
+    <BaseButton variant="dark" class="w-full">Comprar pacote de ingressos</BaseButton>
+    <div v-for="(session, index) in props.sessions[activePage]">
+      <PeliculaSessionCard class="mb-400" :session="session" />
+      <hr v-show="index < 2" class="text-neutrals-300">
+    </div>
+    <div class="flex items-center justify-center gap-600">
+      <button
+        v-if="pagesTotal > 1"
+        type="button"
+        :disabled="activePage == 0"
+        class="text-neutrasl-700 cursor-pointer disabled:pointer-events-none disabled:text-neutrals-300"
+        @click="() => { activePage--; scrollToTopOfSessions(); }"
+      >
+        <IconChevronLeft />
+      </button>
+      <p class="flex items-center gap-200 text-neutrals-500">
+        <span>{{ activePage + 1 }}</span>/<span>{{ pagesTotal }}</span>
+      </p>
+
+      <button
+        v-if="pagesTotal > 1"
+        type="button"
+        :disabled="activePage >= pagesTotal - 1"
+        class="text-neutrasl-700 disabled:text-neutrals-300 cursor-pointer disabled:pointer-events-none"
+        @click="() => { activePage++; scrollToTopOfSessions(); }"
+      >
+        <IconChevronRight />
+      </button>
+    </div>
   </div>
 </template>
 

--- a/app/frontend/components/ui/CarouselComponent.vue
+++ b/app/frontend/components/ui/CarouselComponent.vue
@@ -14,11 +14,21 @@ const props = defineProps({
     required: true,
     default: () => []
   },
-  classNames: Array
+  classNames: Array,
+  fullScreen: { type: Boolean, default: false }
 })
 
 const imageLabel = (image) => {
   return image?.label || null
+}
+
+const navigatorsXPositionClass = (side) => {
+  if (side === "left") {
+    return props.fullScreen ? 'lg:translate-x-2400' : 'lg:translate-x-0'
+  }
+  if (side === "right") {
+    return props.fullScreen ? 'lg:-translate-x-2400' : 'lg:translate-x-0'
+  }
 }
 
 </script>
@@ -39,8 +49,8 @@ const imageLabel = (image) => {
         </figure>
       </CarouselItem>
     </CarouselContent>
-    <CarouselPrevious class="translate-x-[56px] scale-70 lg:translate-x-0 lg:scale-100"/>
-    <CarouselNext class="translate-x-[-56px] scale-70 lg:translate-x-0 lg:scale-100" />
+    <CarouselPrevious :class="['translate-x-[56px] scale-70 lg:scale-100', navigatorsXPositionClass('left')]"/>
+    <CarouselNext :class="['translate-x-[-56px] scale-70 lg:scale-100', navigatorsXPositionClass('right')]" />
   </Carousel>
 </template>
 

--- a/app/frontend/lib/utils.js
+++ b/app/frontend/lib/utils.js
@@ -30,7 +30,7 @@ export function useUpdateWindowWidth() {
   const width = ref(typeof window !== 'undefined' ? window.innerWidth : 0)
   const updateWidth = () => width.value = window.innerWidth
 
-  const isDesktop = computed(() => width.value >= 740)
+  const isDesktop = computed(() => width.value >= 1024)
 
   onMounted(() => window.addEventListener('resize', updateWidth))
   onUnmounted(() => window.removeEventListener('resize', updateWidth))

--- a/app/frontend/lib/utils.js
+++ b/app/frontend/lib/utils.js
@@ -1,5 +1,6 @@
 import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
@@ -23,4 +24,16 @@ export function slugify(str) {
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
+}
+
+export function useUpdateWindowWidth() {
+  const width = ref(typeof window !== 'undefined' ? window.innerWidth : 0)
+  const updateWidth = () => width.value = window.innerWidth
+
+  const isDesktop = computed(() => width.value >= 740)
+
+  onMounted(() => window.addEventListener('resize', updateWidth))
+  onUnmounted(() => window.removeEventListener('resize', updateWidth))
+
+  return isDesktop
 }

--- a/app/frontend/pages/Peliculas/Show.vue
+++ b/app/frontend/pages/Peliculas/Show.vue
@@ -16,6 +16,8 @@ const TwContainer = defineAsyncComponent(() => import('@/components/layout/TwCon
 const TagMostra = defineAsyncComponent(() => import('@/components/common/tags/TagMostra.vue'));
 const TabbedPanel = defineAsyncComponent(() => import('@/components/common/tabs/TabbedPanel.vue'));
 
+import { useUpdateWindowWidth } from '@/lib/utils';
+
 const props = defineProps({
   rootUrl: { type: String, required: true },
   crumbs: { type: Array, required: true, default: () => []},
@@ -30,13 +32,7 @@ const tabs = [
 ]
 const activeTab = ref(tabs[0].id)
 
-const width = ref(typeof window !== 'undefined' ? window.innerWidth : 0)
-const isDesktop = computed(() => width.value >= 740)
-
-const updateWidth = () => width.value = window.innerWidth
-
-onMounted(() => window.addEventListener('resize', updateWidth))
-onUnmounted(() => window.removeEventListener('resize', updateWidth))
+const isDesktop = useUpdateWindowWidth();
 </script>
 
 <template>
@@ -110,7 +106,7 @@ onUnmounted(() => window.removeEventListener('resize', updateWidth))
     <!-- EACH SHOULD BE A COMPONENT LAZY LOADED -->
     <div class="flex flex-col justify-center gap-6 sm:flex-row sm:gap-800 py-600">
 
-      <section v-show="activeTab === 'creditos' || isDesktop" class="w-full sm:w-1/3">
+      <section v-if="activeTab === 'creditos' || isDesktop" class="w-full sm:w-1/3">
         <!-- EACH SHOULD BE A COMPONENT LAZY LOADED -->
         <Suspense>
           <CreditosContent
@@ -128,7 +124,7 @@ onUnmounted(() => window.removeEventListener('resize', updateWidth))
         </Suspense>
       </section>
 
-      <section v-show="activeTab === 'informacoes' || isDesktop" class="w-full sm:w-2/3">
+      <section v-if="activeTab === 'informacoes' || isDesktop" class="w-full sm:w-2/3">
         <Suspense>
           <InformacoesContent
             :display_sinopse="props.pelicula.display_sinopse"
@@ -144,7 +140,7 @@ onUnmounted(() => window.removeEventListener('resize', updateWidth))
         </Suspense>
       </section>
 
-      <section v-show="activeTab === 'sessoes' || isDesktop" class="w-full sm:w-1/3 space-y-400">
+      <section v-if="activeTab === 'sessoes' || isDesktop" class="w-full sm:w-1/3 space-y-400">
         <Suspense>
           <SessoesContent />
           <template #fallback>

--- a/app/frontend/pages/Peliculas/Show.vue
+++ b/app/frontend/pages/Peliculas/Show.vue
@@ -133,7 +133,7 @@ const isDesktop = useUpdateWindowWidth();
 
       <section v-if="activeTab === 'second' || isDesktop" class="w-full lg:w-1/3 space-y-400">
         <Suspense>
-          <SessoesContent />
+          <SessoesContent :sessions="pelicula.programacoesAsJson"/>
           <template #fallback>
             <div class="animate-pulse bg-gray-200 h-32 rounded"></div>
           </template>

--- a/app/frontend/pages/Peliculas/Show.vue
+++ b/app/frontend/pages/Peliculas/Show.vue
@@ -110,7 +110,7 @@ const isDesktop = useUpdateWindowWidth();
     <!-- EACH SHOULD BE A COMPONENT LAZY LOADED -->
     <div class="flex flex-col justify-center gap-6 sm:flex-row sm:gap-800 py-600">
 
-      <section v-if="activeTab === 'third' || isDesktop" class="w-full sm:w-1/3">
+      <section v-if="activeTab === 'third' || isDesktop" class="w-full lg:w-1/3">
         <!-- EACH SHOULD BE A COMPONENT LAZY LOADED -->
         <Suspense>
           <CreditosContent :pelicula="pelicula"/>
@@ -120,7 +120,7 @@ const isDesktop = useUpdateWindowWidth();
         </Suspense>
       </section>
 
-      <section v-if="activeTab === 'first' || isDesktop" class="w-full sm:w-2/3">
+      <section v-if="activeTab === 'first' || isDesktop" class="w-full lg:w-2/3">
 
           <Suspense>
             <InformacoesContent :pelicula="pelicula"
@@ -131,7 +131,7 @@ const isDesktop = useUpdateWindowWidth();
           </Suspense>
         </section>
 
-      <section v-if="activeTab === 'second' || isDesktop" class="w-full sm:w-1/3 space-y-400">
+      <section v-if="activeTab === 'second' || isDesktop" class="w-full lg:w-1/3 space-y-400">
         <Suspense>
           <SessoesContent />
           <template #fallback>

--- a/app/frontend/pages/Peliculas/Show.vue
+++ b/app/frontend/pages/Peliculas/Show.vue
@@ -4,7 +4,7 @@
 // TODO: Fix carousel só se tiver imagem para mostrar
 // TODO: E se filme nao tiver imagem na db?
 
-import { ref, computed, onMounted, onUnmounted, defineAsyncComponent } from 'vue';
+import { ref, defineAsyncComponent } from 'vue';
 
 const InformacoesContent = defineAsyncComponent(() => import('@/components/features/peliculas/InformacoesContent.vue'));
 const SessoesContent = defineAsyncComponent(() => import('@/components/features/peliculas/SessoesContent.vue'));
@@ -15,6 +15,7 @@ const IconChevronLeft = defineAsyncComponent(() => import('@/components/common/i
 const TwContainer = defineAsyncComponent(() => import('@/components/layout/TwContainer.vue'));
 const TagMostra = defineAsyncComponent(() => import('@/components/common/tags/TagMostra.vue'));
 const TabbedPanel = defineAsyncComponent(() => import('@/components/common/tabs/TabbedPanel.vue'));
+const CarouselComponent = defineAsyncComponent(() => import('@/components/ui/CarouselComponent.vue'));
 
 import { useUpdateWindowWidth } from '@/lib/utils';
 
@@ -26,11 +27,13 @@ const props = defineProps({
 });
 
 const tabs = [
-  { id: 'informacoes', label: 'Informações' },
-  { id: 'sessoes', label: 'Sessões' },
-  { id: 'creditos', label: 'Créditos' }
+  { id: 'first', label: 'Informações' },
+  { id: 'second', label: 'Sessões' },
+  { id: 'third', label: 'Créditos' }
 ]
-const activeTab = ref(tabs[0].id)
+
+const startingTab = 0
+const activeTab = ref(tabs[startingTab].id)
 
 const isDesktop = useUpdateWindowWidth();
 </script>
@@ -98,7 +101,8 @@ const isDesktop = useUpdateWindowWidth();
       </TwContainer>
     </div>
   </header>
-     <!-- Tabs -->
+
+  <!-- Tabs -->
   <TwContainer>
 
     <TabbedPanel v-model="activeTab" :tabs="tabs" class="py-400 justify-center lg:hidden" />
@@ -106,41 +110,28 @@ const isDesktop = useUpdateWindowWidth();
     <!-- EACH SHOULD BE A COMPONENT LAZY LOADED -->
     <div class="flex flex-col justify-center gap-6 sm:flex-row sm:gap-800 py-600">
 
-      <section v-if="activeTab === 'creditos' || isDesktop" class="w-full sm:w-1/3">
+      <section v-if="activeTab === 'third' || isDesktop" class="w-full sm:w-1/3">
         <!-- EACH SHOULD BE A COMPONENT LAZY LOADED -->
         <Suspense>
-          <CreditosContent
-            :director_image="props.pelicula.director_image"
-            :diretor_coord_int="props.pelicula.diretor_coord_int"
-            :roteiro_team="props.pelicula.roteiro_team"
-            :fotografia_team="props.pelicula.fotografia_team"
-            :montagem_team="props.pelicula.montagem_team"
-            :diretor_team="props.pelicula.diretor_team"
-            :producaoempresa_team="props.pelicula.producaoempresa_team"
-          />
+          <CreditosContent :pelicula="pelicula"/>
           <template #fallback>
             <div class="animate-pulse bg-gray-200 h-32 rounded"></div>
           </template>
         </Suspense>
       </section>
 
-      <section v-if="activeTab === 'informacoes' || isDesktop" class="w-full sm:w-2/3">
-        <Suspense>
-          <InformacoesContent
-            :display_sinopse="props.pelicula.display_sinopse"
-            :imageURL="props.pelicula.imageURL"
-            :display_titulo="props.pelicula.display_titulo"
-            :mostra_tag_class="props.pelicula.mostra_tag_class"
-            :mostra_name="props.pelicula.mostra_name"
-            :carousel_images="props.pelicula.carousel_images"
-          />
-          <template #fallback>
-            <div class="animate-pulse bg-gray-200 h-32 rounded"></div>
-          </template>
-        </Suspense>
-      </section>
+      <section v-if="activeTab === 'first' || isDesktop" class="w-full sm:w-2/3">
 
-      <section v-if="activeTab === 'sessoes' || isDesktop" class="w-full sm:w-1/3 space-y-400">
+          <Suspense>
+            <InformacoesContent :pelicula="pelicula"
+            />
+            <template #fallback>
+              <div class="animate-pulse bg-gray-200 h-32 rounded"></div>
+            </template>
+          </Suspense>
+        </section>
+
+      <section v-if="activeTab === 'second' || isDesktop" class="w-full sm:w-1/3 space-y-400">
         <Suspense>
           <SessoesContent />
           <template #fallback>
@@ -150,6 +141,13 @@ const isDesktop = useUpdateWindowWidth();
       </section>
     </div>
   </TwContainer>
+
+  <Suspense v-if="isDesktop">
+    <CarouselComponent :full-screen="true" :imageCollection="props.pelicula.carousel_images" :class-names="['pt-800']" />
+    <template #fallback>
+      <div class="h-48 bg-gray-200 animate-pulse rounded pt-800"></div>
+    </template>
+  </Suspense>
 </template>
 
 <style scoped>

--- a/app/frontend/pages/ProgramPage.vue
+++ b/app/frontend/pages/ProgramPage.vue
@@ -195,7 +195,7 @@ const handleClear = () => {
 // sticket menutabs
 const { sentinel, isSticky } = useStickyMenuTabs();
 
-// const debugMode = false;
+const debugMode = false;
 </script>
 
 <template>
@@ -272,7 +272,7 @@ const { sentinel, isSticky } = useStickyMenuTabs();
           @filtersApplied="filterSearch"
           @filtersCleared="clearSearchQuery"
           @close-filter-menu="closeMenu"
-          :debugMode="debugMode || false"
+          :debugMode="debugMode"
           >
           <template #filters="searchFilterProps">
             <!-- v-bind="searchFilterProps" -->

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -19,6 +19,7 @@ class Pelicula < ApplicationRecord
     genre
     mostra_name
     mostra_tag_class
+    programacoesAsJson
   ]
   COLUMNS_NEEDED = %i[
     elenco_coord_int
@@ -62,6 +63,13 @@ class Pelicula < ApplicationRecord
     collection_for(:elenco_coord_int, :elenco) do |actors|
       actors.flat_map { |cast| cast.split(",").map(&:strip) }
     end
+  end
+
+  def programacoesAsJson
+    JSON.parse(programacoes.to_json(
+      only: [ :id, :data, :sessao, :ingresso_url_venda ],
+      methods: [ :display_sessao, :cinema_name, :cinema_address ]
+    ))
   end
 
   def genre

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -129,7 +129,8 @@ class Pelicula < ApplicationRecord
     mostra.tag_class
   end
 
-  def posterImageURL(image_name = nil, size = "original")
+  # TODO: Define default size for all images in the website
+  def posterImageURL(image_name = nil, size = "large")
     image_name ||= self.imagem_producao
       # TODO: CACHE
       # TODO: IF WE WANT DIFFERENT SIZE?

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -120,12 +120,12 @@ class Pelicula < ApplicationRecord
     mostra.tag_class
   end
 
-  def imageURL(image_name = nil)
+  def imageURL(image_name = nil, size = "original")
     image_name ||= self.imagem
       # TODO: CACHE
       # TODO: IF WE WANT DIFFERENT SIZE?
       # Rails.cache.fetch("image-for-pelicula-#{id}", expires_in: 12.hours) do
-      "#{ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_ENV")}/#{ApplicationRecord::EDICAO_ATUAL_ANO}/site/peliculas/large/#{image_name}"
+      "#{ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_ENV")}/#{ApplicationRecord::EDICAO_ATUAL_ANO}/site/peliculas/#{size}/#{image_name}"
     # end
   end
 

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -12,6 +12,7 @@ class Pelicula < ApplicationRecord
     roteiro_team
     montagem_team
     imageURL
+    posterImageURL
     director_image
     carousel_images
     display_paises
@@ -118,6 +119,15 @@ class Pelicula < ApplicationRecord
 
   def mostra_tag_class
     mostra.tag_class
+  end
+
+  def posterImageURL(image_name = nil, size = "original")
+    image_name ||= self.imagem_producao
+      # TODO: CACHE
+      # TODO: IF WE WANT DIFFERENT SIZE?
+      # Rails.cache.fetch("image-for-pelicula-#{id}", expires_in: 12.hours) do
+      "#{ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_ENV")}/#{ApplicationRecord::EDICAO_ATUAL_ANO}/site/peliculas/#{size}/#{image_name}"
+    # end
   end
 
   def imageURL(image_name = nil, size = "original")

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -66,10 +66,17 @@ class Pelicula < ApplicationRecord
   end
 
   def programacoesAsJson
-    JSON.parse(programacoes.to_json(
-      only: [ :id, :data, :sessao, :ingresso_url_venda ],
-      methods: [ :display_sessao, :cinema_name, :cinema_address ]
-    ))
+    programacoes.order(:data).each_slice(3).map do |programacoes_slice|
+      programacoes_slice.map do |prog|
+        {
+          data: prog.display_date,
+          sessao: prog.display_sessao,
+          ingresso_url_venda: prog.ingresso_url_venda,
+          cinema_name: prog.cinema_name,
+          cinema_address: prog.cinema_address
+        }
+      end
+    end
   end
 
   def genre

--- a/app/models/programacao.rb
+++ b/app/models/programacao.rb
@@ -11,6 +11,14 @@ class Programacao < ApplicationRecord
     sessao.strftime("%H:%M")
   end
 
+  def cinema_name
+    cinema.nome
+  end
+
+  def cinema_address
+    cinema.endereco
+  end
+
   def filter_value
     sessao.strftime("%Hh%M")
   end

--- a/app/models/programacao.rb
+++ b/app/models/programacao.rb
@@ -11,6 +11,14 @@ class Programacao < ApplicationRecord
     sessao.strftime("%H:%M")
   end
 
+  def display_date
+    if I18n.locale == :pt
+      I18n.l(self.data, format: "%a, %e %b", locale: :pt).split(" ").map(&:strip).join(" ")
+    else
+      I18n.l(self.data, format: "%a, %b %e", locale: :en).split(" ").map(&:strip).join(" ")
+    end
+  end
+
   def cinema_name
     cinema.nome
   end


### PR DESCRIPTION
- PeliculaCreditoCard.vue — A card component to display credit/member info for a movie (pelicula).
- PeliculaPosterCard.vue — A card component for rendering movie posters, likely including image + metadata.
- useUpdateWindowWidth() in lib/utils.js — a composable that tracks window.innerWidth and returns a computed boolean isDesktop (true when width ≥ 1024px). Useful for controlling layout / behavior depending on viewport.
- In CarouselComponent.vue, there’s a new prop fullScreen (boolean, default false) that changes navigator positioning (left/right) depending on whether the carousel is shown full screen or not.
- Updated logic for navigator “X” position classes via a helper navigatorsXPositionClass(side) that considers fullScreen in its calculations.
- 