### PR TITLE
Riff 7 tv festival UI

### DIFF
--- a/app/frontend/assets/css/typography.css
+++ b/app/frontend/assets/css/typography.css
@@ -1,6 +1,5 @@
 @import "./tailwind-config.css" reference;
 
-
 @layer components {
   /*
    * TYPOGRAPHY STYLES - Pure typography properties only
@@ -42,6 +41,10 @@
     @apply text-neutrals-900 font-body text-lg font-regular leading-[140%];
   }
 
+  .text-body-regular-md {
+    @apply font-body text-md font-regular leading-[140%];
+  }
+
   .text-body-strong-xs {
     @apply font-body text-xs font-semibold leading-[140%];
   }
@@ -51,7 +54,7 @@
   }
 
   .text-body-regular-line-small {
-    @apply font-body text-sm font-regular underline underline-offset-auto leading-[140%]
+    @apply font-body text-sm font-regular underline underline-offset-auto leading-[140%];
   }
 
   .text-subheading {
@@ -60,7 +63,7 @@
 
   /* Header variants */
   .text-header-xxl {
-    @apply font-heading font-regular text-3xl leading-[120%]
+    @apply font-heading font-regular text-3xl leading-[120%];
   }
 
   .text-header-base {
@@ -125,7 +128,7 @@
   }
 
   .text-gradient {
-    @apply bg-clip-text text-transparent bg-gradient-to-r from-magenta-600 to-laranja-600 hover:bg-gradient-to-l active:bg-gradient-to-r
+    @apply bg-clip-text text-transparent bg-gradient-to-r from-magenta-600 to-laranja-600 hover:bg-gradient-to-l active:bg-gradient-to-r;
   }
 }
 

--- a/app/frontend/components/features/peliculas/VideoBanner.vue
+++ b/app/frontend/components/features/peliculas/VideoBanner.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, computed } from 'vue'
-import { IconPlay } from '@/components/common/icons'
+import { ref, computed } from "vue";
+import { IconPlay } from "@/components/common/icons";
 
 const props = defineProps({
   youtubeVideoId: { type: String, default: null },
@@ -15,68 +15,70 @@ const isPlaying = ref(false)
 
 // Extract YouTube ID from URL
 const getYouTubeId = (url) => {
-  if (!url) return null
-  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/)
-  return match ? match[1] : null
-}
+  if (!url) return null;
+  const match = url.match(
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+  );
+  return match ? match[1] : null;
+};
 
 // Extract Vimeo ID from URL
 const getVimeoId = (url) => {
-  if (!url) return null
-  const match = url.match(/vimeo\.com\/(\d+)/)
-  return match ? match[1] : null
-}
+  if (!url) return null;
+  const match = url.match(/vimeo\.com\/(\d+)/);
+  return match ? match[1] : null;
+};
 
 // Get embed URL for video
 const embedUrl = computed(() => {
   // Priority: embedded iframe > youtube link > vimeo link
   if (props.youtubeEmbedTrailer) {
-    const srcMatch = props.youtubeEmbedTrailer.match(/src="([^"]+)"/)
+    const srcMatch = props.youtubeEmbedTrailer.match(/src="([^"]+)"/);
     if (srcMatch) {
-      return srcMatch[1] + '&autoplay=1'
+      return srcMatch[1] + "&autoplay=1";
     }
   }
 
   if (props.youtubeLinkTrailer) {
-    const youtubeId = getYouTubeId(props.youtubeLinkTrailer)
+    const youtubeId = getYouTubeId(props.youtubeLinkTrailer);
     if (youtubeId) {
-      return `https://www.youtube.com/embed/${youtubeId}?autoplay=1&rel=0`
+      return `https://www.youtube.com/embed/${youtubeId}?autoplay=1&rel=0`;
     }
   }
 
   if (props.vimeoLinkTrailer) {
-    const vimeoId = getVimeoId(props.vimeoLinkTrailer)
+    const vimeoId = getVimeoId(props.vimeoLinkTrailer);
     if (vimeoId) {
-      return `https://player.vimeo.com/video/${vimeoId}?autoplay=1&title=0&byline=0&portrait=0`
+      return `https://player.vimeo.com/video/${vimeoId}?autoplay=1&title=0&byline=0&portrait=0`;
     }
   }
 
   if (props.youtubeVideoId) {
-    return `https://www.youtube.com/embed/${props.youtubeVideoId}?autoplay=1&controls=1&rel=0&mute=1`
+    return `https://www.youtube.com/embed/${props.youtubeVideoId}?autoplay=1&controls=1&rel=0&mute=1&modestbranding=1&showinfo=0`;
   }
 
-  return null
-})
+  return null;
+});
 
 // Get thumbnail URL
 const thumbnailUrl = computed(() => {
   if (props.youtubeLinkTrailer) {
-    const youtubeId = getYouTubeId(props.youtubeLinkTrailer)
+    const youtubeId = getYouTubeId(props.youtubeLinkTrailer);
     if (youtubeId) {
-      return `https://i.ytimg.com/vi/${youtubeId}/maxresdefault.jpg`
+      return `https://i.ytimg.com/vi/${youtubeId}/maxresdefault.jpg`;
     }
   }
   if (props.youtubeVideoId) {
-    return `https://i.ytimg.com/vi/${props.youtubeVideoId}/maxresdefault.jpg`
+    return `https://i.ytimg.com/vi/${props.youtubeVideoId}/maxresdefault.jpg`;
   }
 
   // For Vimeo, we'd need API call for thumbnail, use fallback for now
-  return props.fallbackImage
-})
+  return props.fallbackImage;
+});
 
 const playVideo = () => {
-  isPlaying.value = true
-}
+  isPlaying.value = true;
+};
 </script>
 
 <template>
@@ -90,14 +92,20 @@ const playVideo = () => {
 
   <!-- Video banner wrapper -->
   <div v-else class="relative w-full aspect-video lg:mx-auto rounded-200">
-
     <!-- Iframe layer: mounted when playing -->
     <iframe
       v-if="isPlaying"
       :src="embedUrl"
       class="absolute inset-0 z-[100] w-full h-full rounded-200"
       frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allow="
+        accelerometer;
+        autoplay;
+        clipboard-write;
+        encrypted-media;
+        gyroscope;
+        picture-in-picture;
+      "
       allowfullscreen
     ></iframe>
     <!-- Thumbnail + play button overlay -->
@@ -111,21 +119,28 @@ const playVideo = () => {
         v-if="thumbnailUrl"
         :src="thumbnailUrl"
         :alt="title"
-        class="w-full h-full object-cover"
+        class="w-full h-full object-cover rounded-200"
       />
-      <div v-else class="w-full h-full bg-gradient-to-br from-primary to-secondary"></div>
+      <div
+        v-else
+        class="w-full h-full bg-gradient-to-br from-primary to-secondary"
+      ></div>
 
       <!-- Dark overlay -->
       <div class="absolute inset-0 bg-black/40"></div>
 
       <!-- Play button -->
       <div class="absolute inset-0 flex items-center justify-center">
-        <div class="bg-white-transp-1000/70 rounded-200 p-4 group-hover:bg-white-transp-1000/100 transition-all duration-300 group-hover:scale-105">
+        <div
+          class="bg-white-transp-1000/70 rounded-200 p-4 group-hover:bg-white-transp-1000/100 transition-all duration-300 group-hover:scale-105"
+        >
           <IconPlay class="w-8 h-8 text-neutrals-900 ml-1" />
         </div>
       </div>
     </div>
-    <div class="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/80 to-transparent p-4 z-10">
+    <div
+      class="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/80 to-transparent p-4 z-10 rounded-200"
+    >
       <p class="text-white text-md leading-[140%] font-body font-regular">
         {{ title }}
       </p>

--- a/app/frontend/components/features/peliculas/VideoBanner.vue
+++ b/app/frontend/components/features/peliculas/VideoBanner.vue
@@ -149,7 +149,7 @@ const playVideo = () => {
       </div>
     </div>
     <div
-      v-if="showTitle"
+      v-if="showTitle && !isPlaying"
       class="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/80 to-transparent p-4 z-10 rounded-200"
     >
       <p class="text-white text-md leading-[140%] font-body font-regular">

--- a/app/frontend/components/features/peliculas/VideoBanner.vue
+++ b/app/frontend/components/features/peliculas/VideoBanner.vue
@@ -8,10 +8,12 @@ const props = defineProps({
   youtubeLinkTrailer: { type: String, default: null },
   vimeoLinkTrailer: { type: String, default: null },
   fallbackImage: { type: String, default: null },
-  title: { type: String, default: 'Video Banner' }
-})
+  title: { type: String, default: "Video Banner" },
+  showPlay: { type: Boolean, default: true },
+  showTitle: { type: Boolean, default: true },
+});
 
-const isPlaying = ref(false)
+const isPlaying = ref(false);
 
 // Extract YouTube ID from URL
 const getYouTubeId = (url) => {
@@ -127,10 +129,18 @@ const playVideo = () => {
       ></div>
 
       <!-- Dark overlay -->
-      <div class="absolute inset-0 bg-black/40"></div>
+      <div
+        class="absolute inset-0 transition-opacity duration-300"
+        :class="
+          showPlay ? 'bg-black/40' : 'bg-black/20 group-hover:bg-black/30'
+        "
+      ></div>
 
       <!-- Play button -->
-      <div class="absolute inset-0 flex items-center justify-center">
+      <div
+        v-if="showPlay"
+        class="absolute inset-0 flex items-center justify-center"
+      >
         <div
           class="bg-white-transp-1000/70 rounded-200 p-4 group-hover:bg-white-transp-1000/100 transition-all duration-300 group-hover:scale-105"
         >
@@ -139,6 +149,7 @@ const playVideo = () => {
       </div>
     </div>
     <div
+      v-if="showTitle"
       class="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/80 to-transparent p-4 z-10 rounded-200"
     >
       <p class="text-white text-md leading-[140%] font-body font-regular">

--- a/app/frontend/components/layout/TvFestival.vue
+++ b/app/frontend/components/layout/TvFestival.vue
@@ -20,7 +20,7 @@ const { activeIndex, mainVideo, sideVideos, selectVideo } = useVideoSelection(
 <template>
   <div class="tv-festival bg-neutrals-1000 py-1600">
     <TwContainer>
-      <div class="text-white">
+      <div v-if="mainVideo" class="text-white">
         <!-- DESKTOP: grid 3 colunas -->
         <div class="hidden lg:grid grid-cols-3 gap-8 mx-auto">
           <!-- LEFT -->
@@ -78,7 +78,7 @@ const { activeIndex, mainVideo, sideVideos, selectVideo } = useVideoSelection(
         </div>
 
         <!-- MOBILE: vídeo principal + carrossel -->
-        <div class="flex flex-col gap-4 lg:hidden">
+        <div v-if="mainVideo" class="flex flex-col gap-4 lg:hidden">
           <!-- Vídeo principal -->
           <div class="aspect-video bg-black rounded-200">
             <VideoBanner
@@ -104,7 +104,7 @@ const { activeIndex, mainVideo, sideVideos, selectVideo } = useVideoSelection(
           </div>
           <!-- Carrossel horizontal -->
           <div
-            class="flex gap-3 overflow-x-auto pb-2 -mx-4 px-4 snap-x snap-mandatory scrollbar-hide"
+            class="flex gap-3 overflow-x-auto pb-2 px-4 snap-x snap-mandatory scrollbar-hide"
           >
             <div
               v-for="{ video, index } in sideVideos"

--- a/app/frontend/components/layout/TvFestival.vue
+++ b/app/frontend/components/layout/TvFestival.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { defineAsyncComponent, ref, computed } from "vue";
+import { ref, computed } from "vue";
 import TwContainer from "./TwContainer.vue";
 import VideoBanner from "@/components/features/peliculas/VideoBanner.vue";
-
-const CarouselComponent = defineAsyncComponent(
-  () => import("@/components/ui/CarouselComponent.vue"),
-);
-import CarouselItem from "@/components/ui/carousel/CarouselItem.vue";
 
 const props = defineProps({
   youtubeVideos: {
@@ -93,29 +88,5 @@ function selectVideo(index) {
         </div>
       </div>
     </TwContainer>
-  </div>
-
-  <div v-if="false">
-    <div class="tv-festival bg-neutrals-1000 py-1600">
-      <TwContainer>
-        <div class="flex flex-col gap-800">
-          <h3
-            class="text-white-transp-1000 leading-[120%] font-regular text-3xl"
-          >
-            TV Festival do Rio
-          </h3>
-
-          <CarouselComponent :full-screen="true">
-            <template v-slot:items>
-              <CarouselItem
-                v-for="(youtubeVideo, index) in youtubeVideos"
-                :key="youtubeVideo['id']"
-              >
-              </CarouselItem>
-            </template>
-          </CarouselComponent>
-        </div>
-      </TwContainer>
-    </div>
   </div>
 </template>

--- a/app/frontend/components/layout/TvFestival.vue
+++ b/app/frontend/components/layout/TvFestival.vue
@@ -1,38 +1,121 @@
 <script setup>
-import { defineAsyncComponent } from 'vue';
-import TwContainer from './TwContainer.vue';
-const VideoBanner = defineAsyncComponent(() => import( "@/components/features/peliculas/VideoBanner.vue"));
-const CarouselComponent = defineAsyncComponent(() => import( "@/components/ui/CarouselComponent.vue"));
-const CarouselItem = defineAsyncComponent(() => import( "@/components/ui/carousel/CarouselItem.vue"));
+import { defineAsyncComponent, ref, computed } from "vue";
+import TwContainer from "./TwContainer.vue";
+import VideoBanner from "@/components/features/peliculas/VideoBanner.vue";
 
-defineProps({
+const CarouselComponent = defineAsyncComponent(
+  () => import("@/components/ui/CarouselComponent.vue"),
+);
+import CarouselItem from "@/components/ui/carousel/CarouselItem.vue";
+
+const props = defineProps({
   youtubeVideos: {
     type: Array,
     required: true,
-    default: () => []
-  }
-})
+    default: () => [],
+  },
+});
+
+// Índice do vídeo principal
+const activeIndex = ref(0);
+
+// Vídeo principal
+const mainVideo = computed(() => props.youtubeVideos[activeIndex.value]);
+
+// Vídeos da sidebar (todos exceto o principal, limitado a 3)
+const sideVideos = computed(() =>
+  props.youtubeVideos
+    .map((video, index) => ({ video, index }))
+    .filter(({ index }) => index !== activeIndex.value)
+    .slice(0, 3),
+);
+
+function selectVideo(index) {
+  activeIndex.value = index;
+}
 </script>
 
 <template>
   <div class="tv-festival bg-neutrals-1000 py-1600">
     <TwContainer>
-      <div class="flex flex-col gap-800">
-        <h3 class="text-white-transp-1000 leading-[120%] font-regular text-3xl">TV Festival do Rio</h3>
-
-        <CarouselComponent :full-screen="true">
-          <template v-slot:items>
-            <CarouselItem v-for="(youtubeVideo, index) in youtubeVideos" :key="youtubeVideo['id']">
+      <div class="text-white">
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 mx-auto">
+          <!-- LEFT -->
+          <div class="lg:col-span-2 flex flex-col gap-4 justify-center">
+            <div class="aspect-video bg-black rounded-200">
               <VideoBanner
-                :youtube-video-id="youtubeVideo['snippet']['resourceId']['videoId']"
-                :title="youtubeVideo['snippet']['title']"
+                :youtube-video-id="
+                  mainVideo['snippet']['resourceId']['videoId']
+                "
+                :title="mainVideo['snippet']['title']"
+              />
+            </div>
+
+            <div>
+              <h2 class="text-xl font-semibold mb-2">
+                {{ mainVideo["snippet"]["title"] }}
+              </h2>
+              <p class="text-sm text-neutral-300">
+                A 26ª edição do #FestivaldoRio foi um marco inesquecível,
+                repleta de histórias emocionantes, trocas culturais e encontros
+                que celebraram a magia do cinema! Agradecemos imensamente o
+                apoio de nossos patrocinadores Shell Brasil e Prefeitura do Rio
+                de Janeiro, que todo ano se comprometem em tornar o sonho
+                realidade. <br /><br />
+                No vemos novamente em 2025!!
+              </p>
+            </div>
+          </div>
+
+          <!-- RIGHT -->
+          <div class="flex flex-col justify-between h-full">
+            <div
+              v-for="{ video, index } in sideVideos"
+              :key="video['id']"
+              class="flex flex-col h-[255px] cursor-pointer group"
+              @click="selectVideo(index)"
+            >
+              <!-- item -->
+              <div
+                class="aspect-video w-full max-h-[180px] bg-neutral-700 rounded-md"
+              >
+                <VideoBanner
+                  :youtube-video-id="video['snippet']['resourceId']['videoId']"
+                  :title="video['snippet']['title']"
                 />
-            </CarouselItem>
-          </template>
-        </CarouselComponent>
+              </div>
+
+              <!-- <p class="text-sm mt-2 line-clamp-2">
+                Noite de Encerramento com os vencedores do Festival do Rio 2024
+              </p> -->
+            </div>
+          </div>
+        </div>
       </div>
     </TwContainer>
   </div>
-</template>
 
-<style scoped></style>
+  <div v-if="false">
+    <div class="tv-festival bg-neutrals-1000 py-1600">
+      <TwContainer>
+        <div class="flex flex-col gap-800">
+          <h3
+            class="text-white-transp-1000 leading-[120%] font-regular text-3xl"
+          >
+            TV Festival do Rio
+          </h3>
+
+          <CarouselComponent :full-screen="true">
+            <template v-slot:items>
+              <CarouselItem
+                v-for="(youtubeVideo, index) in youtubeVideos"
+                :key="youtubeVideo['id']"
+              >
+              </CarouselItem>
+            </template>
+          </CarouselComponent>
+        </div>
+      </TwContainer>
+    </div>
+  </div>
+</template>

--- a/app/frontend/components/layout/TvFestival.vue
+++ b/app/frontend/components/layout/TvFestival.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from "vue";
 import TwContainer from "./TwContainer.vue";
 import VideoBanner from "@/components/features/peliculas/VideoBanner.vue";
+import { useVideoSelection } from "@/composables/useVideoSelection";
 
 const props = defineProps({
   youtubeVideos: {
@@ -11,41 +12,28 @@ const props = defineProps({
   },
 });
 
-// Índice do vídeo principal
-const activeIndex = ref(0);
-
-// Vídeo principal
-const mainVideo = computed(() => props.youtubeVideos[activeIndex.value]);
-
-// Vídeos da sidebar (todos exceto o principal, limitado a 3)
-const sideVideos = computed(() =>
-  props.youtubeVideos
-    .map((video, index) => ({ video, index }))
-    .filter(({ index }) => index !== activeIndex.value)
-    .slice(0, 3),
+const { activeIndex, mainVideo, sideVideos, selectVideo } = useVideoSelection(
+  computed(() => props.youtubeVideos),
 );
-
-function selectVideo(index) {
-  activeIndex.value = index;
-}
 </script>
 
 <template>
   <div class="tv-festival bg-neutrals-1000 py-1600">
     <TwContainer>
       <div class="text-white">
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 mx-auto">
+        <!-- DESKTOP: grid 3 colunas -->
+        <div class="hidden lg:grid grid-cols-3 gap-8 mx-auto">
           <!-- LEFT -->
-          <div class="lg:col-span-2 flex flex-col gap-4 justify-center">
+          <div class="col-span-2 flex flex-col gap-4 justify-center">
             <div class="aspect-video bg-black rounded-200">
               <VideoBanner
                 :youtube-video-id="
                   mainVideo['snippet']['resourceId']['videoId']
                 "
                 :title="mainVideo['snippet']['title']"
+                :show-title="false"
               />
             </div>
-
             <div>
               <h2 class="text-xl font-semibold mb-2">
                 {{ mainVideo["snippet"]["title"] }}
@@ -56,33 +44,93 @@ function selectVideo(index) {
                 que celebraram a magia do cinema! Agradecemos imensamente o
                 apoio de nossos patrocinadores Shell Brasil e Prefeitura do Rio
                 de Janeiro, que todo ano se comprometem em tornar o sonho
-                realidade. <br /><br />
-                No vemos novamente em 2025!!
+                realidade.<br /><br />
+                Nos vemos novamente em 2025!!
               </p>
             </div>
           </div>
 
           <!-- RIGHT -->
-          <div class="flex flex-col justify-between h-full">
+          <div class="flex flex-col gap-800 justify-between h-full">
             <div
               v-for="{ video, index } in sideVideos"
               :key="video['id']"
-              class="flex flex-col h-[255px] cursor-pointer group"
+              class="flex flex-col cursor-pointer group"
               @click="selectVideo(index)"
             >
-              <!-- item -->
               <div
-                class="aspect-video w-full max-h-[180px] bg-neutral-700 rounded-md"
+                class="aspect-video w-full max-h-[180px] bg-neutral-700 rounded-md overflow-hidden ring-2 ring-transparent group-hover:ring-white/40 transition-all duration-200"
               >
                 <VideoBanner
                   :youtube-video-id="video['snippet']['resourceId']['videoId']"
                   :title="video['snippet']['title']"
+                  :show-title="false"
+                  :show-play="false"
+                />
+              </div>
+              <p
+                class="text-sm mt-2 line-clamp-2 text-neutral-300 group-hover:text-white transition-colors"
+              >
+                {{ video["snippet"]["title"] }}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- MOBILE: vídeo principal + carrossel -->
+        <div class="flex flex-col gap-4 lg:hidden">
+          <!-- Vídeo principal -->
+          <div class="aspect-video bg-black rounded-200">
+            <VideoBanner
+              :youtube-video-id="mainVideo['snippet']['resourceId']['videoId']"
+              :title="mainVideo['snippet']['title']"
+              :show-title="false"
+            />
+          </div>
+
+          <!-- Título e descrição -->
+          <div>
+            <h2 class="text-body-regular-md mb-2">
+              {{ mainVideo["snippet"]["title"] }}
+            </h2>
+            <p class="text-body-regular">
+              A 26ª edição do #FestivaldoRio foi um marco inesquecível, repleta
+              de histórias emocionantes, trocas culturais e encontros que
+              celebraram a magia do cinema! Agradecemos imensamente o apoio de
+              nossos patrocinadores Shell Brasil e Prefeitura do Rio de Janeiro,
+              que todo ano se comprometem em tornar o sonho realidade.<br /><br />
+              Nos vemos novamente em 2025!!
+            </p>
+          </div>
+          <!-- Carrossel horizontal -->
+          <div
+            class="flex gap-3 overflow-x-auto pb-2 -mx-4 px-4 snap-x snap-mandatory scrollbar-hide"
+          >
+            <div
+              v-for="{ video, index } in sideVideos"
+              :key="video['id']"
+              class="flex-none w-[240px] cursor-pointer group snap-start flex flex-col gap-2"
+              @click="selectVideo(index)"
+            >
+              <!-- Vídeo: aspect-video fluido -->
+              <div
+                class="w-full aspect-video bg-neutral-700 rounded-md overflow-hidden ring-2 ring-transparent group-hover:ring-white/40 transition-all duration-200"
+                :class="{ 'ring-white/60': activeIndex === index }"
+              >
+                <VideoBanner
+                  :youtube-video-id="video['snippet']['resourceId']['videoId']"
+                  :title="video['snippet']['title']"
+                  :show-play="false"
+                  :show-title="false"
                 />
               </div>
 
-              <!-- <p class="text-sm mt-2 line-clamp-2">
-                Noite de Encerramento com os vencedores do Festival do Rio 2024
-              </p> -->
+              <!-- Texto -->
+              <p
+                class="text-sm line-clamp-2 text-neutral-300 group-hover:text-white transition-colors leading-snug"
+              >
+                {{ video["snippet"]["title"] }}
+              </p>
             </div>
           </div>
         </div>

--- a/app/frontend/composables/useVideoSelection.js
+++ b/app/frontend/composables/useVideoSelection.js
@@ -1,0 +1,17 @@
+// useVideoSelection.js
+import { ref, computed } from "vue";
+
+export function useVideoSelection(videos) {
+  const activeIndex = ref(0);
+  const mainVideo = computed(() => videos.value[activeIndex.value]);
+  const sideVideos = computed(() =>
+    videos.value
+      .map((video, index) => ({ video, index }))
+      .filter(({ index }) => index !== activeIndex.value)
+      .slice(0, 3),
+  );
+  function selectVideo(index) {
+    activeIndex.value = index;
+  }
+  return { activeIndex, mainVideo, sideVideos, selectVideo };
+}

--- a/app/frontend/tests/composables/useVideoSelection.test.js
+++ b/app/frontend/tests/composables/useVideoSelection.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { computed, ref } from "vue";
+import { useVideoSelection } from "@/composables/useVideoSelection";
+
+const mockVideos = [
+  { id: "1", snippet: { title: "Video A", resourceId: { videoId: "aaaa" } } },
+  { id: "2", snippet: { title: "Video B", resourceId: { videoId: "bbbb" } } },
+  { id: "3", snippet: { title: "Video C", resourceId: { videoId: "cccc" } } },
+  { id: "4", snippet: { title: "Video D", resourceId: { videoId: "dddd" } } },
+  { id: "5", snippet: { title: "Video E", resourceId: { videoId: "eeee" } } },
+];
+
+const makeVideos = (list = mockVideos) => computed(() => list);
+
+describe("useVideoSelection", () => {
+  it("starts with activeIndex 0", () => {
+    const { activeIndex } = useVideoSelection(makeVideos());
+    expect(activeIndex.value).toBe(0);
+  });
+
+  it("mainVideo returns the video at activeIndex", () => {
+    const { mainVideo } = useVideoSelection(makeVideos());
+    expect(mainVideo.value.id).toBe("1");
+  });
+
+  it("sideVideos excludes the main video", () => {
+    const { sideVideos } = useVideoSelection(makeVideos());
+    const ids = sideVideos.value.map(({ video }) => video.id);
+    expect(ids).not.toContain("1");
+  });
+
+  it("sideVideos returns at most 3 items", () => {
+    const { sideVideos } = useVideoSelection(makeVideos());
+    expect(sideVideos.value.length).toBeLessThanOrEqual(3);
+  });
+
+  it("sideVideos preserves original index", () => {
+    const { sideVideos } = useVideoSelection(makeVideos());
+
+    expect(sideVideos.value[0].index).toBe(1);
+  });
+
+  it("selectVideo updates activeIndex", () => {
+    const { activeIndex, selectVideo } = useVideoSelection(makeVideos());
+    selectVideo(2);
+    expect(activeIndex.value).toBe(2);
+  });
+
+  it("mainVideo updates reactively after selectVideo", () => {
+    const { mainVideo, selectVideo } = useVideoSelection(makeVideos());
+    selectVideo(3);
+    expect(mainVideo.value.id).toBe("4");
+  });
+
+  it("sideVideos updates reactively after selectVideo", () => {
+    const { sideVideos, selectVideo } = useVideoSelection(makeVideos());
+    selectVideo(1);
+    const ids = sideVideos.value.map(({ video }) => video.id);
+    expect(ids).not.toContain("2");
+    expect(ids).toContain("1");
+  });
+
+  it("works with exactly 1 video", () => {
+    const { mainVideo, sideVideos } = useVideoSelection(
+      makeVideos([mockVideos[0]]),
+    );
+    expect(mainVideo.value.id).toBe("1");
+    expect(sideVideos.value.length).toBe(0);
+  });
+
+  it("works with exactly 4 videos — sideVideos caps at 3", () => {
+    const { sideVideos } = useVideoSelection(
+      makeVideos(mockVideos.slice(0, 4)),
+    );
+    expect(sideVideos.value.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Refactors the `TvFestival` component to support interactive video selection, responsive layout, and cleaner architecture.

- Clicking a side video promotes it to the main player; the previous main moves to the sidebar
- Mobile layout: main video + title/description stacked, followed by a horizontal snap carousel
- Desktop layout: main video (2/3) + sidebar with up to 3 thumbnails (1/3)
- Extracted selection logic into `useVideoSelection` composable with full test coverage
- Added `showPlay` and `showTitle` props to `VideoBanner` for granular control per context

## Context

The previous implementation used a static `CarouselComponent` with no interactivity. This PR delivers the TV Festival section as a fully interactive video hub, matching the Figma spec for both mobile and desktop breakpoints.

## Verification

- [x] Tests pass locally (`vitest run tests/composables/useVideoSelection.test.js`)
- [x] Clicking side videos swaps correctly on desktop and mobile
- [x] Mobile carousel scrolls horizontally with snap behavior
- [x] Side thumbnails show no play button and no title overlay
- [x] Main video shows play button and title below the player

## Screenshots

<!-- Add screen recording of the swap interaction on mobile and desktop -->
#### Desktop
<img width="1470" height="891" alt="image" src="https://github.com/user-attachments/assets/1d9ac347-1947-45ce-909c-441b81b0c2ec" />

#### Mobile
<img width="485" height="779" alt="image" src="https://github.com/user-attachments/assets/459a8f11-f057-4137-a45b-419065df0668" />

--- 

https://github.com/user-attachments/assets/64173ed7-cceb-454d-9031-6f928e1f7344

