### PR TITLE
RIF-4: Refactor to usehorizontal scroll inside containert 

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -74,6 +74,26 @@ class PagesController < ApplicationController
       methods: %i[ permalink mobile_image_url desktop_image_url ]
     )
 
+    destaques_by_tipo = Destaque
+      .active
+      .includes(:tipo)
+      .group_by(&:tipo)
+      .map do |tipo, grupo|
+        {
+          tipo_id:   tipo.id,
+          tipo_nome: I18n.locale == :pt ? tipo.nome_pt : tipo.nome_en,
+          items: grupo.first(5).map do |d|
+            {
+              id:      d.id,
+              titulo:  d.titulo,
+              url:     d.url,
+              destino: d.destino,
+              imagem:  d.image_url
+            }
+          end
+        }
+      end
+
     render inertia: "HomePage", props: {
       rootUrl: @root_url,
       quickLinksConfig:,
@@ -81,6 +101,7 @@ class PagesController < ApplicationController
       noticasUrl: noticias_url,
       youtubeVideos: playlist_response["items"],
       nextSessions: @programacoes,
+      destaques: destaques_by_tipo,
       webdoors:
     }
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -79,19 +79,9 @@ class PagesController < ApplicationController
       .includes(:tipo)
       .group_by(&:tipo)
       .map do |tipo, grupo|
-        {
-          tipo_id:   tipo.id,
-          tipo_nome: I18n.locale == :pt ? tipo.nome_pt : tipo.nome_en,
-          items: grupo.first(5).map do |d|
-            {
-              id:      d.id,
-              titulo:  d.titulo,
-              url:     d.url,
-              destino: d.destino,
-              imagem:  d.image_url
-            }
-          end
-        }
+        TipoSerializer.new(tipo).as_json.merge(
+          items: grupo.first(5).map { |d| DestaqueSerializer.new(d).as_json }
+        )
       end
 
     render inertia: "HomePage", props: {

--- a/app/frontend/components/common/cards/DestaqueCard.vue
+++ b/app/frontend/components/common/cards/DestaqueCard.vue
@@ -1,0 +1,25 @@
+<script setup>
+defineProps({
+  titulo: { type: String, required: true },
+  imagem: { type: String, required: true },
+  url: { type: String, required: true },
+  destino: { type: String, default: "_self" },
+});
+</script>
+
+<template>
+  <div class="flex flex-col gap-y-200">
+    <a :href="url" :target="destino" rel="noopener noreferrer">
+      <img
+        :src="imagem"
+        :alt="titulo"
+        class="aspect-video w-full object-cover rounded-200"
+      />
+    </a>
+    <h3 class="text-header-sm text-primary">
+      <a :href="url" :target="destino" rel="noopener noreferrer">
+        {{ titulo }}
+      </a>
+    </h3>
+  </div>
+</template>

--- a/app/frontend/components/features/home/DestaquesSection.vue
+++ b/app/frontend/components/features/home/DestaquesSection.vue
@@ -1,0 +1,37 @@
+<script setup>
+import HorizontalScrollLayout from "@/components/layout/HorizontalScrollLayout.vue";
+import DestaqueCard from "@/components/common/cards/DestaqueCard.vue";
+
+defineProps({
+  tipoNome: { type: String, required: true },
+  items: { type: Array, required: true, default: () => [] },
+});
+</script>
+
+<template>
+  <div class="py-800">
+    <HorizontalScrollLayout
+      variant="light"
+      mobile-variant="dark"
+      :mobile-scroll-distance="0.4"
+    >
+      <template #header>
+        <h3 class="text-header-xxl text-neutrals-900">{{ tipoNome }}</h3>
+      </template>
+      <template #content>
+        <div
+          v-for="destaque in items"
+          :key="destaque.id"
+          class="flex-shrink-0 w-full sm:w-1/3 lg:w-1/4 sm:min-w-[280px]"
+        >
+          <DestaqueCard
+            :titulo="destaque.titulo"
+            :imagem="destaque.imagem"
+            :url="destaque.url"
+            :destino="destaque.destino"
+          />
+        </div>
+      </template>
+    </HorizontalScrollLayout>
+  </div>
+</template>

--- a/app/frontend/components/layout/HorizontalScrollLayout.vue
+++ b/app/frontend/components/layout/HorizontalScrollLayout.vue
@@ -1,16 +1,93 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed, onMounted, onUpdated } from "vue";
 import TwContainer from "./TwContainer.vue";
-import { IconChevronRight, IconChevronLeft } from "@/components/common/icons"
+import { IconChevronRight, IconChevronLeft } from "@/components/common/icons";
+
+const props = defineProps({
+  variant: {
+    type: String,
+    default: "dark",
+    validator: (v) => ["dark", "light"].includes(v),
+  },
+  mobileVariant: {
+    type: String,
+    default: null,
+    validator: (v) => v === null || ["dark", "light"].includes(v),
+  },
+  scrollDistance: {
+    type: Number,
+    default: 0.8,
+  },
+  mobileScrollDistance: {
+    type: Number,
+    default: 0.5,
+  },
+});
+
+const iconClasses = computed(() => {
+  if (currentVariant.value === "dark") {
+    return "text-white-transp-800 hover:text-white-transp-1000";
+  }
+  return "cursor-pointer text-neutrals-900 hover:text-neutrals-700";
+});
+
+const disabledIconClasses = computed(() => {
+  if (currentVariant.value === "dark") {
+    return "text-neutrals-400 cursor-not-allowed";
+  }
+  return "text-neutrals-400 cursor-not-allowed";
+});
 
 const scrollContainer = ref(null);
-const width = ref(typeof window !== 'undefined' ? window.innerWidth : 0)
+const width = ref(typeof window !== "undefined" ? window.innerWidth : 0);
+const canScrollLeft = ref(false);
+const canScrollRight = ref(true);
+const isMobile = ref(
+  typeof window !== "undefined" ? window.innerWidth < 1024 : false,
+);
+
+const currentVariant = computed(() => {
+  return isMobile.value && props.mobileVariant
+    ? props.mobileVariant
+    : props.variant;
+});
+
+const currentScrollDistance = computed(() => {
+  return isMobile.value ? props.mobileScrollDistance : props.scrollDistance;
+});
+
+const updateScrollState = () => {
+  if (!scrollContainer.value) return;
+  const { scrollLeft, scrollWidth, clientWidth } = scrollContainer.value;
+  canScrollLeft.value = scrollLeft > 0;
+  canScrollRight.value = scrollLeft + clientWidth < scrollWidth - 10;
+};
+
 const scrollLeft = () => {
-  scrollContainer.value.scrollBy({ left: -width.value*0.80, behavior: 'smooth' });
+  scrollContainer.value.scrollBy({
+    left: -width.value * currentScrollDistance.value,
+    behavior: "smooth",
+  });
 };
 const scrollRight = () => {
-  scrollContainer.value.scrollBy({ left: width.value*0.80, behavior: 'smooth' });
+  scrollContainer.value.scrollBy({
+    left: width.value * currentScrollDistance.value,
+    behavior: "smooth",
+  });
 };
+
+onMounted(() => {
+  updateScrollState();
+  isMobile.value = window.innerWidth < 1024;
+  scrollContainer.value?.addEventListener("scroll", updateScrollState);
+  window.addEventListener("resize", () => {
+    width.value = window.innerWidth;
+    isMobile.value = window.innerWidth < 1024;
+  });
+});
+onUpdated(() => {
+  updateScrollState();
+});
 </script>
 
 <template>
@@ -18,23 +95,42 @@ const scrollRight = () => {
     <TwContainer>
       <slot name="header" />
     </TwContainer>
-    <div ref="scrollContainer" class="flex overflow-x-auto no-scroll-bar gap-800">
+    <div
+      ref="scrollContainer"
+      class="flex overflow-x-auto no-scroll-bar gap-800 scroll-snap-x-mandatory"
+    >
       <slot name="content" />
     </div>
     <button
       @click="scrollLeft"
-      class="absolute left-400 top-1/2 -translate-y-1/2 z-10 bg-transparent hover:text-white-neutrals-900"
-      aria-label="Scroll right"
+      :disabled="!canScrollLeft"
+      class="absolute left-400 top-1/2 -translate-y-1/2 lg:-translate-x-16 z-10 bg-transparent transition-colors"
+      aria-label="Scroll left"
     >
-      <IconChevronLeft class="w-6 h-6 text-white-transp-800" />
+      <IconChevronLeft
+        :class="['w-6 h-6', canScrollLeft ? iconClasses : disabledIconClasses]"
+      />
     </button>
     <button
       @click="scrollRight"
-      class="absolute right-400 top-1/2 -translate-y-1/2 z-10 bg-transparent hover:text-white-transp-1000" aria-label="Scroll right"
+      :disabled="!canScrollRight"
+      class="absolute right-400 top-1/2 -translate-y-1/2 lg:translate-x-16 z-10 bg-transparent transition-colors"
+      aria-label="Scroll right"
     >
-      <IconChevronRight class="w-6 h-6 text-white-transp-800" />
+      <IconChevronRight
+        :class="['w-6 h-6', canScrollRight ? iconClasses : disabledIconClasses]"
+      />
     </button>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.scroll-snap-x-mandatory {
+  scroll-snap-type: x mandatory;
+}
+
+.scroll-snap-x-mandatory > * {
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+</style>

--- a/app/frontend/components/layout/HorizontalScrollLayout.vue
+++ b/app/frontend/components/layout/HorizontalScrollLayout.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, onUpdated } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import TwContainer from "./TwContainer.vue";
 import { IconChevronRight, IconChevronLeft } from "@/components/common/icons";
 
@@ -24,27 +24,9 @@ const props = defineProps({
   },
 });
 
-const iconClasses = computed(() => {
-  if (currentVariant.value === "dark") {
-    return "text-white-transp-800 hover:text-white-transp-1000";
-  }
-  return "cursor-pointer text-neutrals-900 hover:text-neutrals-700";
-});
-
-const disabledIconClasses = computed(() => {
-  if (currentVariant.value === "dark") {
-    return "text-neutrals-400 cursor-not-allowed";
-  }
-  return "text-neutrals-400 cursor-not-allowed";
-});
-
 const scrollContainer = ref(null);
-const width = ref(typeof window !== "undefined" ? window.innerWidth : 0);
-const canScrollLeft = ref(false);
-const canScrollRight = ref(true);
-const isMobile = ref(
-  typeof window !== "undefined" ? window.innerWidth < 1024 : false,
-);
+const width = ref(window.innerWidth);
+const isMobile = computed(() => width.value < 1024);
 
 const currentVariant = computed(() => {
   return isMobile.value && props.mobileVariant
@@ -56,8 +38,21 @@ const currentScrollDistance = computed(() => {
   return isMobile.value ? props.mobileScrollDistance : props.scrollDistance;
 });
 
+const canScrollLeft = ref(false);
+const canScrollRight = ref(true);
+
+const iconClasses = computed(() => {
+  if (currentVariant.value === "dark") {
+    return "text-white-transp-800 hover:text-white-transp-1000";
+  }
+  return "cursor-pointer text-neutrals-900 hover:text-neutrals-700";
+});
+
+const disabledIconClasses = "text-neutrals-400 cursor-not-allowed";
+
 const updateScrollState = () => {
   if (!scrollContainer.value) return;
+
   const { scrollLeft, scrollWidth, clientWidth } = scrollContainer.value;
   canScrollLeft.value = scrollLeft > 0;
   canScrollRight.value = scrollLeft + clientWidth < scrollWidth - 10;
@@ -76,17 +71,17 @@ const scrollRight = () => {
   });
 };
 
+const onResize = () => {
+  width.value = window.innerWidth;
+};
+
 onMounted(() => {
   updateScrollState();
-  isMobile.value = window.innerWidth < 1024;
-  scrollContainer.value?.addEventListener("scroll", updateScrollState);
-  window.addEventListener("resize", () => {
-    width.value = window.innerWidth;
-    isMobile.value = window.innerWidth < 1024;
-  });
+  window.addEventListener("resize", onResize);
 });
-onUpdated(() => {
-  updateScrollState();
+
+onUnmounted(() => {
+  window.removeEventListener("resize", onResize);
 });
 </script>
 
@@ -97,6 +92,7 @@ onUpdated(() => {
     </TwContainer>
     <div
       ref="scrollContainer"
+      @scroll="updateScrollState"
       class="flex overflow-x-auto no-scroll-bar gap-800 scroll-snap-x-mandatory"
     >
       <slot name="content" />

--- a/app/frontend/pages/HomePage.vue
+++ b/app/frontend/pages/HomePage.vue
@@ -1,21 +1,21 @@
 <script setup>
 import { Head } from "@inertiajs/vue3";
 import { ref, defineAsyncComponent, computed } from "vue";
-import TwContainer from "@components/layout/TwContainer.vue"
+import TwContainer from "@components/layout/TwContainer.vue";
 
-import HomeBanner from '@/components/features/home/HomeBanner.vue';
+import HomeBanner from "@/components/features/home/HomeBanner.vue";
 import banneImagePath from "@assets/images/mobile-banner.png";
-import QuickLinkSection from '@components/common/cards/QuickLinkSection.vue';
-import ArticlesSection from '@components/features/home/ArticlesSection.vue';
+import QuickLinkSection from "@components/common/cards/QuickLinkSection.vue";
+import ArticlesSection from "@components/features/home/ArticlesSection.vue";
 import NavbarSecondary from "@components/layout/navbar/NavbarSecondary.vue";
 import SessionCard from "@/components/common/cards/SessionCard.vue";
 import HorizontalScrollLayout from "@/components/layout/HorizontalScrollLayout.vue";
-import TvFestival from"@/components/layout/TvFestival.vue";
+import TvFestival from "@/components/layout/TvFestival.vue";
+import DestaquesSection from "@/components/features/home/DestaquesSection.vue";
 
 import { simpleTranslation, useUpdateWindowWidth } from "@/lib/utils";
 import CarouselComponent from "@/components/ui/CarouselComponent.vue";
 import { CarouselItem } from "@/components/ui/carousel";
-
 
 const props = defineProps({
   quickLinksConfig: { type: Array },
@@ -25,14 +25,17 @@ const props = defineProps({
   noticasUrl: { type: String },
   youtubeVideos: { type: Array },
   nextSessions: { type: Array },
-  webdoors: { type: Array }
-})
+  webdoors: { type: Array },
+  destaques: { type: Array, default: () => [] },
+});
 const isDesktop = ref(useUpdateWindowWidth());
 
 const mobileSizing = "height: 562px;";
 
 const backgroundImageStyle = (webdoor) => {
-  const imagePath = isDesktop.value ? webdoor.desktop_image_url : webdoor.mobile_image_url
+  const imagePath = isDesktop.value
+    ? webdoor.desktop_image_url
+    : webdoor.mobile_image_url;
   return `background-image: url(${imagePath});
     background-position: center;
     background-size: cover;
@@ -52,12 +55,19 @@ const backgroundImageStyle = (webdoor) => {
     <CarouselComponent :full-screen="true">
       <template v-slot:items>
         <CarouselItem v-for="webdoor in props.webdoors" :key="webdoor.id">
-          <div class="flex items-end justify-start h-[562px] lg:h-[618px]" :style="[backgroundImageStyle(webdoor)]">
-               <div class="px-400 py-200 lg:ps-[150px] lg:max-w-5xl pb-[58px] lg:pb-[77px]">
-                 <h1 class="banner font-regular leading-[150%] text-2xl lg:text-3xl mb-200 text-primary">
-                 {{ webdoor.titulo }}
-                 </h1>
-               </div>
+          <div
+            class="flex items-end justify-start h-[562px] lg:h-[618px]"
+            :style="[backgroundImageStyle(webdoor)]"
+          >
+            <div
+              class="px-400 py-200 lg:ps-[150px] lg:max-w-5xl pb-[58px] lg:pb-[77px]"
+            >
+              <h1
+                class="banner font-regular leading-[150%] text-2xl lg:text-3xl mb-200 text-primary"
+              >
+                {{ webdoor.titulo }}
+              </h1>
+            </div>
             <!-- </TwContainer> -->
           </div>
         </CarouselItem>
@@ -66,35 +76,54 @@ const backgroundImageStyle = (webdoor) => {
   </HomeBanner>
   <QuickLinkSection v-bind:links="quickLinksConfig" />
 
-
-  <div class="py-1600">
-    <HorizontalScrollLayout>
-      <template v-slot:header>
-        <h3 class="text-header-xxl text-neutrals-900">{{ simpleTranslation("Próximas sessões", "Upcoming sessions") }}</h3>
-      </template>
-      <template v-slot:content>
-        <div class="flex-shrink-0 w-[calc(80%-0.75rem)] sm:w-[calc(30%-0.75rem)] sm:min-w-[300px]"
-          v-for="(session, index) in props.nextSessions" :key="session.id">
-          <SessionCard :session="session" />
-        </div>
-      </template>
-    </HorizontalScrollLayout>
-  </div>
-  <!-- </div> -->
-  <TwContainer>
-  </TwContainer>
   <TwContainer>
     <div class="py-1200">
-      <ArticlesSection :articles="props.noticias" :noticiasUrl="props.noticasUrl"/>
+      <ArticlesSection
+        :articles="props.noticias"
+        :noticiasUrl="props.noticasUrl"
+      />
     </div>
-
   </TwContainer>
   <TvFestival :youtube-videos="props.youtubeVideos" />
+
+  <div class="py-1200">
+    <TwContainer>
+      <HorizontalScrollLayout variant="light" mobile-variant="dark">
+        <template v-slot:header>
+          <h3 class="text-header-xxl text-neutrals-900">
+            {{ simpleTranslation("Próximas sessões", "Upcoming sessions") }}
+          </h3>
+        </template>
+        <template v-slot:content>
+          <div
+            class="flex-shrink-0 w-[calc(80%-0.75rem)] sm:w-[calc(30%-0.75rem)] sm:min-w-[300px]"
+            v-for="(session, index) in props.nextSessions"
+            :key="session.id"
+          >
+            <SessionCard :session="session" />
+          </div>
+        </template>
+      </HorizontalScrollLayout>
+    </TwContainer>
+  </div>
+  <TwContainer>
+    <DestaquesSection
+      v-for="grupo in props.destaques"
+      :key="grupo.tipo_id"
+      :tipo-nome="grupo.tipo_nome"
+      :items="grupo.items"
+    />
+  </TwContainer>
 </template>
 
 <style scoped>
 .fade-out--right {
-  -webkit-mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%);
+  -webkit-mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black 85%,
+    transparent 100%
+  );
   mask-image: linear-gradient(to right, black 0%, black 85%, transparent 100%);
   -webkit-mask-size: 100% 100%;
   mask-size: 100% 100%;
@@ -104,5 +133,4 @@ h1.banner {
   display: inline;
   /* line-height: 1.4; */
 }
-
 </style>

--- a/app/models/destaque.rb
+++ b/app/models/destaque.rb
@@ -1,4 +1,13 @@
 class Destaque < ApplicationRecord
   belongs_to :idioma
   belongs_to :tipo
+  BASE_IMAGE_PATH = "/imagens/destaques/small"
+
+  scope :active, -> { where(ativo: 1).order(:ordem) }
+
+  def image_url
+    return "" if imagem.blank?
+
+    "#{ENV.fetch("IMAGES_BASE_URL")}#{BASE_IMAGE_PATH}/#{imagem}"
+  end
 end

--- a/app/serializers/destaque_serializer.rb
+++ b/app/serializers/destaque_serializer.rb
@@ -1,0 +1,15 @@
+class DestaqueSerializer
+  def initialize(destaque)
+    @destaque = destaque
+  end
+
+  def as_json
+    {
+      id: @destaque.id,
+      titulo: @destaque.titulo,
+      url: @destaque.url,
+      destino: @destaque.destino,
+      imagem: @destaque.image_url
+    }
+  end
+end

--- a/app/serializers/tipo_serializer.rb
+++ b/app/serializers/tipo_serializer.rb
@@ -1,0 +1,13 @@
+class TipoSerializer
+  def initialize(tipo, locale: I18n.locale)
+    @tipo = tipo
+    @locale = locale
+  end
+
+  def as_json
+    {
+      tipo_id: @tipo.id,
+      tipo_nome: @locale == :pt ? @tipo.nome_pt : @tipo.nome_en
+    }
+  end
+end

--- a/test/fixtures/destaques.yml
+++ b/test/fixtures/destaques.yml
@@ -1,0 +1,23 @@
+karim_ainouz:
+  idioma: port
+  tipo: meu_redentor
+  titulo: Maior vencedor do Troféu Redentor de melhor direção
+  imagem: d738b0f25ac52d8a9f5cd24ffa25c352.jpg
+  url: https://www.festivaldorio.com.br/br/noticias/maior-vencedor
+  destino: _self
+  ordem: 1
+  ativo: 1
+  created: 2024-10-13 09:40:30
+  updated: 2024-10-13 09:40:30
+
+lucia_murat:
+  idioma: port
+  tipo: meu_redentor
+  titulo: Memória, resistência e o poder do diálogo
+  imagem: 5ad97e3a1e036b06f12103a1557f8b6f.jpg
+  url: https://www.festivaldorio.com.br/br/noticias/memoria-resistencia
+  destino: _self
+  ordem: 2
+  ativo: 1
+  created: 2024-10-13 09:41:07
+  updated: 2024-10-13 09:41:07

--- a/test/fixtures/tipos.yml
+++ b/test/fixtures/tipos.yml
@@ -1,0 +1,13 @@
+premiere_brasil:
+  nome_pt: Première Brasil Debates
+  nome_en: Première Brasil Debates
+  permalink_pt: premiere-brasil-debates
+  permalink_en: premiere-brasil-debates
+  created: 2024-10-10 17:25:10
+
+meu_redentor:
+  nome_pt: Meu Redentor
+  nome_en: My Redeemer
+  permalink_pt: meu-redentor
+  permalink_en: my-redeemer
+  created: 2024-10-10 17:25:10

--- a/test/serializers/destaque_serializer_test.rb
+++ b/test/serializers/destaque_serializer_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class DestaqueSerializerTest < ActiveSupport::TestCase
+  setup do
+    @destaque = destaques(:karim_ainouz)
+  end
+
+  test "returns expected keys" do
+    result = DestaqueSerializer.new(@destaque).as_json
+    assert_equal %i[id titulo url destino imagem], result.keys
+  end
+
+  test "returns correct field values" do
+    result = DestaqueSerializer.new(@destaque).as_json
+    assert_equal @destaque.id,       result[:id]
+    assert_equal @destaque.titulo,   result[:titulo]
+    assert_equal @destaque.url,      result[:url]
+    assert_equal @destaque.destino,  result[:destino]
+    assert_equal @destaque.image_url, result[:imagem]
+  end
+
+  test "imagem uses image_url helper" do
+    result = DestaqueSerializer.new(@destaque).as_json
+    assert_includes result[:imagem], @destaque.imagem
+  end
+end

--- a/test/serializers/tipo_serializer_test.rb
+++ b/test/serializers/tipo_serializer_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class TipoSerializerTest < ActiveSupport::TestCase
+  setup do
+    @tipo = tipos(:meu_redentor)
+  end
+
+  test "returns tipo_id" do
+    result = TipoSerializer.new(@tipo).as_json
+    assert_equal @tipo.id, result[:tipo_id]
+  end
+
+  test "returns nome_pt when locale is pt" do
+    I18n.with_locale(:pt) do
+      result = TipoSerializer.new(@tipo).as_json
+      assert_equal @tipo.nome_pt, result[:tipo_nome]
+    end
+  end
+
+  test "returns nome_en when locale is en" do
+    I18n.with_locale(:en) do
+      result = TipoSerializer.new(@tipo).as_json
+      assert_equal @tipo.nome_en, result[:tipo_nome]
+    end
+  end
+
+  test "accepts explicit locale override" do
+    result = TipoSerializer.new(@tipo, locale: :en).as_json
+    assert_equal @tipo.nome_en, result[:tipo_nome]
+  end
+end


### PR DESCRIPTION
## Summary

Implementa seção de destaques (highlights) na home page, agrupados por tipo.
Cada tipo exibe até 5 itens em carousel com scroll snap.

### Backend

- Destaque model: scope :active e método image_url
- PagesController#home: query destaques por tipo, serializa e passa via Inertia

### Frontend

- DestaqueCard.vue: card simples com imagem + título
- DestaquesSection.vue: seção por tipo usando HorizontalScrollLayout
- HomePage.vue: renderiza seção por tipo agrupado

### Enhancements a HorizontalScrollLayout

- Variants: variant="dark" (branco) / variant="light" (preto) com hover states
- Mobile config: mobileVariant e mobileScrollDistance pra comportamento
diferente < 1024px
- UX:
  - Scroll snap (item-by-item alignment)
  - Buttons disabled state visual (cor + cursor-not-allowed)
  - Auto-detect mobile breakpoint com resize listener

### Design

- Desktop: 4 itens por view, scroll 80% width
- Mobile (< 1024px): ícones brancos, 2 itens por view, scroll 40% width
