### PR TITLE
RIFF-33: Add regression test for current_filters NameError

### DIFF
--- a/test/controllers/programs_controller_test.rb
+++ b/test/controllers/programs_controller_test.rb
@@ -18,6 +18,22 @@ class ProgramsControllerTest < ActionDispatch::IntegrationTest
     assert props["elements"].any?, "Expected at least one program element"
   end
 
+  test "current_filters returns nil values when no params are provided" do
+    get program_url
+    assert_response :success
+
+    filters = inertia_props["current_filters"]
+
+    assert_nil filters["query"]
+    assert_nil filters["mostra"]
+    assert_nil filters["cinema"]
+    assert_nil filters["pais"]
+    assert_nil filters["genero"]
+    assert_nil filters["sessao"]
+    assert_nil filters["elenco"]
+    assert_nil filters["direcao"]
+  end
+
   test "should return matching elements when query is provided" do
     get program_url, params: { query: "Batman" }
 

--- a/test/controllers/programs_controller_test.rb
+++ b/test/controllers/programs_controller_test.rb
@@ -24,6 +24,9 @@ class ProgramsControllerTest < ActionDispatch::IntegrationTest
 
     filters = inertia_props["current_filters"]
 
+    expected_keys = %w[query mostra cinema pais genero sessao elenco direcao]
+    assert_equal expected_keys.sort, filters.keys.sort, "Missing or extra keys in current_filters"
+
     assert_nil filters["query"]
     assert_nil filters["mostra"]
     assert_nil filters["cinema"]


### PR DESCRIPTION
## Summary

The reported bug described a potential `NameError` when `selected_query`, `selected_actor`, and `selected_director` were used in `current_filters` without being initialized — which would happen when their respective `params` were absent.

**This bug was already resolved** by a prior refactor that extracted the filtering logic from `ProgramsController#index` into `ProgramacoesFilter` (`app/filters/programacoes_filter.rb`). The filter class initializes all `selected_*` variables to `nil` at the top of `#call` (lines 39-46) and returns them via a `Struct`, which guarantees every field always exists — no `NameError` possible.

This PR adds a **regression test** that asserts all `current_filters` keys return `nil` when no params are provided, preventing the bug from being reintroduced.

## Test plan
- [x] New test: `current_filters returns nil values when no params are provided`
- [x] All 43 controller tests passing (334 assertions, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)