### PR TITLE
RIFF-46: centralize edition access and image URL source

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :set_locale, :set_root_url, :current_edicao
+  before_action :set_locale, :set_root_url
 
   inertia_share flash: -> {
     {
@@ -31,10 +31,6 @@ class ApplicationController < ActionController::Base
     ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_AT_ENV_FILE")
   }
 
-  def current_edicao
-    @current_edicao = Edicao.find_by!(descricao: ApplicationRecord::EDICAO_ATUAL_ANO)
-  end
-
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
   end
@@ -55,7 +51,7 @@ class ApplicationController < ActionController::Base
         { name: I18n.t("navigation.programming.free"), path: "" },
         { name: I18n.t("navigation.programming.updates"), path: "" }
       ],
-      I18n.t("navigation.edition.name", edicao_atual: ApplicationRecord::EDICAO_ATUAL_ANO) => [
+      I18n.t("navigation.edition.name", edicao_atual: Edicao.current.descricao) => [
         { name: I18n.t("navigation.todos_os_filmes"), path: peliculas_path },
         { name: I18n.t("navigation.mostras"), path: mostras_path },
         { name: I18n.t("navigation.cinemas"), path: cinemas_path },

--- a/app/controllers/cinemas_controller.rb
+++ b/app/controllers/cinemas_controller.rb
@@ -2,7 +2,7 @@ class CinemasController < ApplicationController
   include BreadcrumbsHelper
 
   def index
-    @cinemas = @current_edicao.cinemas.order(nome: :asc)
+    @cinemas = Edicao.current.cinemas.order(nome: :asc)
     @salas = Cinema.group_salas(@cinemas)
 
     render inertia: "Cinemas/Index", props: {
@@ -10,7 +10,7 @@ class CinemasController < ApplicationController
       cinemas: @salas.as_json,
       crumbs: breadcrumbs(
         [ "", @root_url ],
-        [ I18n.t("navigation.edition.name", edicao_atual: ApplicationRecord::EDICAO_ATUAL_ANO), peliculas_path ],
+        [ I18n.t("navigation.edition.name", edicao_atual: Edicao.current.descricao), peliculas_path ],
         [ "Cinemas", cinemas_path ]
       )
     }

--- a/app/controllers/concerns/program_filter_options.rb
+++ b/app/controllers/concerns/program_filter_options.rb
@@ -19,7 +19,7 @@ module ProgramFilterOptions
   end
 
   def build_sessoes_filter
-    programacoes = Programacao.where(edicao_id: @current_edicao)
+    programacoes = Programacao.where(edicao_id: Edicao.current.id, deletado: 0)
                                .to_a
                                .uniq { |p| p.sessao }
                                .sort_by { |it| it.sessao }
@@ -43,7 +43,7 @@ module ProgramFilterOptions
   end
 
   def build_cinema_filter
-    cinemas = Cinema.where(edicao_id: @current_edicao)
+    cinemas = Cinema.where(edicao_id: Edicao.current.id)
                     .to_a
                     .uniq { |m| m.id }
                     .sort_by { |it| it.nome }
@@ -57,7 +57,7 @@ module ProgramFilterOptions
   end
 
   def build_mostra_filter
-    mostras = Mostra.where(edicao_id: @current_edicao)
+    mostras = Mostra.where(edicao_id: Edicao.current.id)
                     .to_a
                     .uniq { |mostra| mostra.id }
                     .sort_by { |mostra| mostra.permalink_pt }

--- a/app/controllers/equipe_controller.rb
+++ b/app/controllers/equipe_controller.rb
@@ -8,7 +8,7 @@ class EquipeController < ApplicationController
       rootUrl: @root_url,
       crumbs: breadcrumbs(
         [ "", @root_url ],
-        [ I18n.t("navigation.edition.name", edicao_atual: ApplicationRecord::EDICAO_ATUAL_ANO), peliculas_path ],
+        [ I18n.t("navigation.edition.name", edicao_atual: Edicao.current.descricao), peliculas_path ],
         [ I18n.t("navigation.edition.team"), equipe_path(locale: I18n.locale) ]
       ),
       **EquipePageContent.as_props

--- a/app/controllers/mostras_controller.rb
+++ b/app/controllers/mostras_controller.rb
@@ -2,7 +2,7 @@ class MostrasController < ApplicationController
   include BreadcrumbsHelper
 
   def index
-    @mostras = Mostra.includes(:peliculas).where(edicao_id: @current_edicao.id).group_by(&:display_name)
+    @mostras = Mostra.includes(:peliculas).where(edicao_id: Edicao.current.id).group_by(&:display_name)
     @categorias = @mostras.map { |categoria, mostras| {
       name: categoria,
       class: mostras.first.tag_class,
@@ -15,14 +15,14 @@ class MostrasController < ApplicationController
       categorias: @categorias.as_json,
       crumbs: breadcrumbs(
         [ "", @root_url ],
-        [ I18n.t("navigation.edition.name", edicao_atual: ApplicationRecord::EDICAO_ATUAL_ANO), "" ],
+        [ I18n.t("navigation.edition.name", edicao_atual: Edicao.current.descricao), "" ],
         [ I18n.t("navigation.mostras"), mostras_path ]
       )
     }
   end
 
   def show
-    @mostras = @current_edicao.mostras.select { |mostra| mostra.display_name == params[:category] }
+    @mostras = Edicao.current.mostras.select { |mostra| mostra.display_name == params[:category] }
 
     render inertia: "Mostras/Show", props: {
       rootUrl: @root_url,

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -60,12 +60,12 @@ class PagesController < ApplicationController
         cinema: programacao.cinema&.nome,
         titulo: programacao.pelicula&.titulo_portugues_coord_int,
         duracao: programacao.pelicula&.duracao_coord_int,
-        imagem: programacao.pelicula&.imagem,
+        imagem_url: programacao.pelicula&.imageURL,
         genero: programacao.pelicula&.genre,
         paises: programacao.pelicula&.display_paises,
         mostra: programacao.pelicula&.mostra&.display_name,
         mostra_tag_class: programacao.pelicula&.mostra&.tag_class,
-        pelicula_url: pelicula_path(programacao.pelicula.permalink)
+        pelicula_url: pelicula_path(programacao.pelicula.permalink),
       }
     end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
 
     # Get next programacoes
     @programacoes = Programacao
-    .where(edicao_id: ApplicationRecord::EDICAO_ATUAL_ID)
+    .where(edicao_id: Edicao.current.id, deletado: 0)
     .where("TIME(sessao) > ? AND TIME(sessao) < ?", Time.now.strftime("%H:%M:%S"), Time.now.end_of_day.strftime("%H:%M:%S"))
     .order([ :data, :sessao ])
     .limit(9)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -65,7 +65,7 @@ class PagesController < ApplicationController
         paises: programacao.pelicula&.display_paises,
         mostra: programacao.pelicula&.mostra&.display_name,
         mostra_tag_class: programacao.pelicula&.mostra&.tag_class,
-        pelicula_url: pelicula_path(programacao.pelicula.permalink),
+        pelicula_url: pelicula_path(programacao.pelicula.permalink)
       }
     end
 

--- a/app/controllers/peliculas_controller.rb
+++ b/app/controllers/peliculas_controller.rb
@@ -47,7 +47,7 @@ class PeliculasController < ApplicationController
   end
 
   def show
-    @pelicula = Pelicula.includes(:paises, :mostra, programacoes: :cinema).find_by(edicao_id: 12, permalink: params[:permalink])
+    @pelicula = Pelicula.includes(:paises, :mostra, programacoes: :cinema).find_by(edicao_id: Edicao.current.id, permalink: params[:permalink])
     render inertia: "Peliculas/Show", props: {
       rootUrl: @root_url,
       pelicula: @pelicula.as_json(

--- a/app/controllers/peliculas_controller.rb
+++ b/app/controllers/peliculas_controller.rb
@@ -6,14 +6,14 @@ class PeliculasController < ApplicationController
   def index
     @peliculas = Pelicula
                   .includes(programacoes: :cinema)
-                  .where(edicao: @current_edicao)
+                  .where(edicao_id: Edicao.current.id, ativo: true)
                   .order(titulo_portugues_coord_int: :asc)
 
     current_page = params[:page]&.to_i || 1
 
     if params[:query]
       term = "%#{params[:query].downcase}%"
-      @peliculas = @peliculas.where(edicao_id: ApplicationRecord::EDICAO_ATUAL_ID).where(
+      @peliculas = @peliculas.where(
         "LOWER(titulo_ingles_coord_int) LIKE :term OR
         LOWER(titulo_original_coord_int) LIKE :term OR
         LOWER(titulo_portugues_coord_int) LIKE :term OR
@@ -35,7 +35,7 @@ class PeliculasController < ApplicationController
       ),
       crumbs: breadcrumbs(
         [ "", @root_url ],
-        [ I18n.t("navigation.edition.name", edicao_atual: ApplicationRecord::EDICAO_ATUAL_ANO), "" ],
+        [ I18n.t("navigation.edition.name", edicao_atual: Edicao.current.descricao), "" ],
         [ I18n.t("navigation.todos_os_filmes"), peliculas_path ]
       ),
       pagy:  {

--- a/app/controllers/peliculas_controller.rb
+++ b/app/controllers/peliculas_controller.rb
@@ -47,7 +47,7 @@ class PeliculasController < ApplicationController
   end
 
   def show
-    @pelicula = Pelicula.includes(:paises, :mostra, programacoes: :cinema).find_by(edicao_id: Edicao.current.id, permalink: params[:permalink])
+    @pelicula = Pelicula.includes(:paises, :mostra, programacoes: :cinema).find_by!(edicao_id: Edicao.current.id, permalink: params[:permalink])
     render inertia: "Peliculas/Show", props: {
       rootUrl: @root_url,
       pelicula: @pelicula.as_json(

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -13,7 +13,7 @@ class ProgramsController < ApplicationController
     base_scope = Programacao
       .joins(pelicula: :mostra)
       .includes(:cinema, pelicula: :mostra)
-      .where(importacoesprog_id: last_import_id, edicao_id: ApplicationRecord::EDICAO_ATUAL_ID) # TODO: remover importacoes?
+      .where(importacoesprog_id: last_import_id, edicao_id: Edicao.current.id, deletado: 0) # TODO: remover importacoes?
 
     set_filter_options(base_scope)
 

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -58,7 +58,7 @@ class ProgramsController < ApplicationController
         cinema: programacao.cinema&.nome,
         titulo: programacao.pelicula&.titulo_portugues_coord_int,
         duracao: programacao.pelicula&.duracao_coord_int,
-        imagem: programacao.pelicula&.imagem,
+        imagem_url: programacao.pelicula&.imageURL,
         genero: programacao.pelicula&.genre,
         paises: programacao.pelicula&.display_paises,
         mostra: programacao.pelicula&.mostra&.display_name,

--- a/app/filters/programacoes_filter.rb
+++ b/app/filters/programacoes_filter.rb
@@ -22,7 +22,7 @@ class ProgramacoesFilter
   def initialize(relation:, params:, filter_options:, pelicula_collection_service:)
     @relation = relation
     @params = params
-    @edicao_id = ApplicationRecord::EDICAO_ATUAL_ID
+    @edicao_id = Edicao.current.id
     @mostras_filter = filter_options.fetch(:mostras)
     @cinemas_filter = filter_options.fetch(:cinemas)
     @paises_filter = filter_options.fetch(:paises)

--- a/app/frontend/components/common/cards/PeliculaCard.vue
+++ b/app/frontend/components/common/cards/PeliculaCard.vue
@@ -2,30 +2,15 @@
 import { computed, ref } from "vue";
 import { Link } from "@inertiajs/vue3";
 
-import DefaultImage from "@assets/images/poc-poster.jpg"
+import DefaultImage from "@assets/images/poc-poster.jpg";
 import TagMostra from "@/components/common/tags/TagMostra.vue";
 
-// Hover state
 const isHovered = ref(false);
 const props = defineProps({
   pelicula: { type: Object, required: true },
-  edicao: { type: String, default: "2024" },
-  size: { type: String, default: "large" },
 });
-const moviePoster = computed(() => {
-  // TODO: ADD TO ENV
-  const baseUrl = "https://festivaldorio.s3.us-east-1.amazonaws.com"
-
-  const fullUrl = `${baseUrl}/${props.edicao}/site/peliculas/${props.size}`
-  if (props.pelicula.imagem) {
-    return `${fullUrl}/${props.pelicula.imagem}`
-  }
-
-  return DefaultImage
-});
-const movieGenre = computed(() => {
-  return props.pelicula.genre || "TBD";
-});
+const moviePoster = computed(() => props.pelicula.imageURL || DefaultImage);
+const movieGenre = computed(() => props.pelicula.genre || "TBD");
 </script>
 
 <template>
@@ -40,7 +25,7 @@ const movieGenre = computed(() => {
      <Link :href="props.pelicula.url" class="w-full">
       <div class="relative w-full">
         <img
-          :src="props.pelicula.imageURL"
+          :src="moviePoster"
           :alt="props.pelicula.display_titulo"
           class="rounded-200 h-[268px] w-full object-cover"
         />

--- a/app/frontend/components/common/cards/SessionCard.vue
+++ b/app/frontend/components/common/cards/SessionCard.vue
@@ -13,11 +13,11 @@ const props = defineProps({
   size: { type: String, default: "large" },
 });
 const moviePoster = computed(() => {
-  const baseUrl = "https://festivaldorio.s3.us-east-1.amazonaws.com"
+  const baseUrl = "https://festivaldorio.s3.us-east-1.amazonaws.com";
 
-  const fullUrl = `${baseUrl}/${props.edicao}/site/peliculas/${props.size}`
+  const fullUrl = `${baseUrl}/${props.edicao}/site/peliculas/${props.size}`;
   if (props.session.imagem) {
-    return `${fullUrl}/${props.session.imagem}`
+    return `${fullUrl}/${props.session.imagem}`;
   }
 
   return "@assets/poc-poster.jpg";
@@ -36,7 +36,7 @@ const movieGenre = computed(() => {
   >
     <!-- image -->
     <!-- LINK -->
-     <Link :href="props.session.pelicula_url" class="w-full">
+    <Link :href="props.session.pelicula_url" class="w-full">
       <div class="relative w-full">
         <img
           :src="moviePoster"
@@ -61,13 +61,17 @@ const movieGenre = computed(() => {
           :text="props.session.mostra"
         />
 
-        <div class="content absolute bottom-250 left-250 flex flex-col gap-[5px]">
+        <div
+          class="content absolute bottom-250 left-250 flex flex-col gap-[5px]"
+        >
           <!-- LINK movie title -->
           <h2 class="text-header-sm text-on-dark">
             {{ props.session.titulo }}
           </h2>
           <div class="flex items-center gap-200">
-            <span class="text-overline text-on-dark-secondary">{{ props.session.paises }}</span>
+            <span class="text-overline text-on-dark-secondary">{{
+              props.session.paises
+            }}</span>
             <img
               src="@assets/icons/divisor.svg"
               alt="divisor"
@@ -95,7 +99,6 @@ const movieGenre = computed(() => {
         </div>
       </div>
     </Link>
-
 
     <div class="px-200 space-y-250 w-full">
       <div class="flex items-center gap-[6px]">

--- a/app/frontend/components/common/cards/SessionCard.vue
+++ b/app/frontend/components/common/cards/SessionCard.vue
@@ -2,29 +2,17 @@
 import { computed, ref } from "vue";
 import { Link } from "@inertiajs/vue3";
 
+import DefaultImage from "@assets/images/poc-poster.jpg";
 import TagMostra from "@/components/common/tags/TagMostra.vue";
 import TagScreening from "@/components/common/tags/TagScreening.vue";
 import { IconPin } from "@/components/common/icons";
-// Hover state
+
 const isHovered = ref(false);
 const props = defineProps({
   session: { type: Object, required: true },
-  edicao: { type: String, default: "2024" },
-  size: { type: String, default: "large" },
 });
-const moviePoster = computed(() => {
-  const baseUrl = "https://festivaldorio.s3.us-east-1.amazonaws.com";
-
-  const fullUrl = `${baseUrl}/${props.edicao}/site/peliculas/${props.size}`;
-  if (props.session.imagem) {
-    return `${fullUrl}/${props.session.imagem}`;
-  }
-
-  return "@assets/poc-poster.jpg";
-});
-const movieGenre = computed(() => {
-  return props.session.genero || "TBD";
-});
+const moviePoster = computed(() => props.session.imagem_url || DefaultImage);
+const movieGenre = computed(() => props.session.genero || "TBD");
 </script>
 
 <template>

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
-  # TODO: update to present year
-  EDICAO_ATUAL_ANO = "2025"
-  EDICAO_ATUAL_ID = 13
   primary_abstract_class
 
   def self.timestamp_attributes_for_create

--- a/app/models/concerns/Filterable.rb
+++ b/app/models/concerns/Filterable.rb
@@ -30,7 +30,7 @@ module Filterable
     end
 
     def filter_scope(field_name)
-      where(edicao_id: ApplicationRecord::EDICAO_ATUAL_ID)
+      where(edicao_id: Edicao.current.id)
         .where.not(field_name => [ nil, "" ])
         .pluck(field_name)
     end

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -58,6 +58,6 @@ module Imageable
   private
 
   def build_image_url(img_name, img_size = "large2")
-    "#{ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_ENV")}/#{ApplicationRecord::EDICAO_ATUAL_ANO}/site/peliculas/#{img_size}/#{img_name}"
+    "#{ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_ENV")}/#{Edicao.current.descricao}/site/peliculas/#{img_size}/#{img_name}"
   end
 end

--- a/app/models/edicao.rb
+++ b/app/models/edicao.rb
@@ -1,8 +1,22 @@
 class Edicao < ApplicationRecord
+  CURRENT_ID = 13
+
   has_many :programacoes
   has_many :mostras
   has_many :cinemas
   has_many :peliculas
   has_many :importacao_convidados
   has_many :importacoesprogs, class_name: "Importacoesprog"
+
+  def self.current
+    Rails.cache.fetch("edicao/current", expires_in: 1.hour) do
+      find(CURRENT_ID)
+    end
+  end
+
+  def self.previous
+    Rails.cache.fetch("edicao/previous", expires_in: 1.hour) do
+      find(CURRENT_ID - 1)
+    end
+  end
 end

--- a/app/models/edicao.rb
+++ b/app/models/edicao.rb
@@ -9,14 +9,14 @@ class Edicao < ApplicationRecord
   has_many :importacoesprogs, class_name: "Importacoesprog"
 
   def self.current
-    Rails.cache.fetch("edicao/current", expires_in: 1.hour) do
+    Rails.cache.fetch("edicao/current/#{CURRENT_ID}", expires_in: 1.hour) do
       find(CURRENT_ID)
     end
   end
 
   def self.previous
-    Rails.cache.fetch("edicao/previous", expires_in: 1.hour) do
-      find(CURRENT_ID - 1)
+    Rails.cache.fetch("edicao/previous/#{CURRENT_ID}", expires_in: 1.hour) do
+      where("id < ?", CURRENT_ID).order(id: :desc).first
     end
   end
 end

--- a/test/controllers/concerns/program_filter_options_test.rb
+++ b/test/controllers/concerns/program_filter_options_test.rb
@@ -3,12 +3,6 @@ require "test_helper"
 class ProgramFilterOptionsTest < ActionDispatch::IntegrationTest
   class DummyController < ActionController::Base
     include ProgramFilterOptions
-    attr_accessor :current_edicao
-
-    def initialize
-      super
-      @current_edicao = ApplicationRecord::EDICAO_ATUAL_ID
-    end
   end
 
   setup do
@@ -16,7 +10,7 @@ class ProgramFilterOptionsTest < ActionDispatch::IntegrationTest
   end
 
   test "to_filter_collection builds filter array with locale parameter" do
-    mostras = Mostra.where(edicao_id: ApplicationRecord::EDICAO_ATUAL_ID).limit(2).to_a
+    mostras = Mostra.where(edicao_id: Edicao.current.id).limit(2).to_a
 
     result = @controller.send(:to_filter_collection, mostras, "mostra", locale: :pt)
 
@@ -31,7 +25,7 @@ class ProgramFilterOptionsTest < ActionDispatch::IntegrationTest
   end
 
   test "to_filter_collection defaults to I18n.locale when not provided" do
-    mostra = Mostra.where(edicao_id: ApplicationRecord::EDICAO_ATUAL_ID).first
+    mostra = Mostra.where(edicao_id: Edicao.current.id).first
     mostras = [ mostra ]
 
     I18n.with_locale(:en) do

--- a/test/models/concerns/imageable_test.rb
+++ b/test/models/concerns/imageable_test.rb
@@ -12,13 +12,15 @@ class ImageableTest < ActiveSupport::TestCase
     end
   end
 
+  TEST_EDICAO = Struct.new(:descricao, :id).new("2024", 12)
+
   def setup
     @pelicula = DummyPelicula.new(imagem: "test_f01.jpg", imagem_producao: "poster.jpg")
   end
 
   test "imageURL returns correct URL with default parameters" do
     ENV.stub(:fetch, "https://example.com") do
-      stub_const("ApplicationRecord::EDICAO_ATUAL_ANO", "2024") do
+      Edicao.stub(:current, TEST_EDICAO) do
         expected_url = "https://example.com/2024/site/peliculas/original/test_f01.jpg"
         assert_equal expected_url, @pelicula.imageURL
       end
@@ -27,7 +29,7 @@ class ImageableTest < ActiveSupport::TestCase
 
   test "imageURL returns correct URL with custom size" do
     ENV.stub(:fetch, "https://example.com") do
-      stub_const("ApplicationRecord::EDICAO_ATUAL_ANO", "2024") do
+      Edicao.stub(:current, TEST_EDICAO) do
         expected_url = "https://example.com/2024/site/peliculas/large/test_f01.jpg"
         assert_equal expected_url, @pelicula.imageURL(nil, "large")
       end
@@ -41,7 +43,7 @@ class ImageableTest < ActiveSupport::TestCase
 
   test "banner_image returns src, srcset, and sizes for responsive banner" do
     ENV.stub(:fetch, "https://example.com") do
-      stub_const("ApplicationRecord::EDICAO_ATUAL_ANO", "2024") do
+      Edicao.stub(:current, TEST_EDICAO) do
         banner = @pelicula.banner_image
         assert_equal "https://example.com/2024/site/peliculas/large/test_f01.jpg", banner[:src]
         assert_includes banner[:srcset], "https://example.com/2024/site/peliculas/large/test_f01.jpg 300w"
@@ -58,7 +60,7 @@ class ImageableTest < ActiveSupport::TestCase
 
   test "posterImageURL returns correct poster URL" do
     ENV.stub(:fetch, "https://example.com") do
-      stub_const("ApplicationRecord::EDICAO_ATUAL_ANO", "2024") do
+      Edicao.stub(:current, TEST_EDICAO) do
         expected_url = "https://example.com/2024/site/peliculas/large/poster.jpg"
         assert_equal expected_url, @pelicula.posterImageURL
       end
@@ -67,36 +69,17 @@ class ImageableTest < ActiveSupport::TestCase
 
   test "carousel_images generates carousel image URLs" do
     ENV.stub(:fetch, "https://example.com") do
-      stub_const("ApplicationRecord::EDICAO_ATUAL_ANO", "2024") do
-          # stub_const("DummyPelicula::CAROUSEL_IMAGES_AMOUNT", 3) do
-          images = @pelicula.carousel_images
-          assert_equal 2, images.length
-          assert_includes images.first[:path], "test_f02.jpg"
-          assert_includes images.last[:path], "test_f03.jpg"
-        end
-      # end
+      Edicao.stub(:current, TEST_EDICAO) do
+        images = @pelicula.carousel_images
+        assert_equal 2, images.length
+        assert_includes images.first[:path], "test_f02.jpg"
+        assert_includes images.last[:path], "test_f03.jpg"
+      end
     end
   end
 
   test "carousel_images returns empty array for blank image" do
     @pelicula.imagem = ""
     assert_equal [], @pelicula.carousel_images
-  end
-
-  private
-
-  # Mimic stub_const from RSpec in Minitest
-  def stub_const(constant, value)
-    parts = constant.to_s.split("::")
-    parent = parts[0..-2].inject(Object) { |mod, name| mod.const_get(name) }
-    name = parts.last
-
-    original = parent.const_get(name)
-    parent.send(:remove_const, name)
-    parent.const_set(name, value)
-    yield
-  ensure
-    parent.send(:remove_const, name)
-    parent.const_set(name, original)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,26 +37,19 @@ class Minitest::Test
   def before_setup
     super
 
-    # Save originals
-    @old_ano    = ApplicationRecord::EDICAO_ATUAL_ANO
-    @old_edicao = ApplicationRecord::EDICAO_ATUAL_ID
-
-    # Override for all tests
-    ApplicationRecord.send(:remove_const, :EDICAO_ATUAL_ANO)
-    ApplicationRecord.const_set(:EDICAO_ATUAL_ANO, "2024")
-
-    ApplicationRecord.send(:remove_const, :EDICAO_ATUAL_ID)
-    ApplicationRecord.const_set(:EDICAO_ATUAL_ID, 12)
+    @old_current_id = Edicao::CURRENT_ID
+    Edicao.send(:remove_const, :CURRENT_ID)
+    Edicao.const_set(:CURRENT_ID, 12)
+    Rails.cache.delete("edicao/current")
+    Rails.cache.delete("edicao/previous")
   end
 
   def after_teardown
     super
 
-    # Restore originals
-    ApplicationRecord.send(:remove_const, :EDICAO_ATUAL_ANO)
-    ApplicationRecord.const_set(:EDICAO_ATUAL_ANO, @old_ano)
-
-    ApplicationRecord.send(:remove_const, :EDICAO_ATUAL_ID)
-    ApplicationRecord.const_set(:EDICAO_ATUAL_ID, @old_edicao)
+    Edicao.send(:remove_const, :CURRENT_ID)
+    Edicao.const_set(:CURRENT_ID, @old_current_id)
+    Rails.cache.delete("edicao/current")
+    Rails.cache.delete("edicao/previous")
   end
 end


### PR DESCRIPTION
## Summary

- Introduce `Edicao.current` (and `Edicao.previous`) as single source of truth for the active edition, backed by Rails cache
- Remove scattered `ApplicationRecord::EDICAO_ATUAL_ANO` constant references across controllers, models, filters, and Vue components
- Image URL construction in `Imageable` now derives edition year from `Edicao.current` instead of the hardcoded constant

## Context

Controllers were each calling `current_edicao` before_action and components referenced a hardcoded constant. Centralizing through `Edicao.current` makes edition changes a one-line update and reduces coupling between layers. Related to RIFF-46.

## Verification

- [ ] Tests pass locally
- [ ] Manually verified the changes

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->