### PR TITLE
RIFF-20: Talents participants page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,7 +61,7 @@ class ApplicationController < ActionController::Base
       I18n.t("navigation.festival.name") => [
         { name: I18n.t("navigation.about.name"), path: "" },
         { name: I18n.t("navigation.edicoes_anteriores"), path: edicoes_anteriores_path },
-        { name: I18n.t("navigation.talent_press"), path: "" },
+        { name: I18n.t("navigation.talent_press"), path: talents_members_path },
         { name: I18n.t("navigation.parceiros"), path: "" }
       ],
       I18n.t("navigation.articles.name") => [

--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -1,0 +1,11 @@
+class TalentsController < ApplicationController
+  def participants
+    @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :apresentacao)
+
+    render inertia: "Talents/Apresentacao", props: {
+      pagina: @pagina,
+      sections: TalentsContentParser.parse(@pagina&.conteudo),
+      tabs: TalentsTabs.build(active: "sobre")
+    }
+  end
+end

--- a/app/frontend/assets/css/typography.css
+++ b/app/frontend/assets/css/typography.css
@@ -45,6 +45,10 @@
     @apply font-body text-md font-regular leading-[140%];
   }
 
+  .text-body-regular-double {
+    @apply font-body text-md font-regular leading-[200%];
+  }
+
   .text-body-strong-xs {
     @apply font-body text-xs font-semibold leading-[140%];
   }

--- a/app/frontend/components/common/SectionHeader.vue
+++ b/app/frontend/components/common/SectionHeader.vue
@@ -1,0 +1,11 @@
+<script setup>
+</script>
+
+<template>
+  <div class="flex flex-col gap-150">
+    <h2 class="text-header-xl text-primary">
+      <slot />
+    </h2>
+    <div class="h-px bg-gradient-to-r from-magenta-600 to-laranja-600"></div>
+  </div>
+</template>

--- a/app/frontend/components/common/cards/JuriCard.vue
+++ b/app/frontend/components/common/cards/JuriCard.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  photo: { type: String, required: true },
+  name: { type: String, required: true },
+  role: { type: String, required: false, default: "" },
+  bio: {
+    type: [String, Array],
+    required: false,
+    default: () => [],
+  },
+});
+
+const bioParagraphs = computed(() => {
+  if (Array.isArray(props.bio)) return props.bio.filter((p) => p && p.trim());
+  return props.bio && props.bio.trim() ? [props.bio] : [];
+});
+</script>
+
+<template>
+  <div class="flex gap-400 items-start text-primary">
+    <img
+      :src="photo"
+      :alt="name"
+      class="size-[180px] shrink-0 object-cover rounded-200"
+      loading="lazy"
+    />
+    <div class="flex-1 flex flex-col gap-150">
+      <p class="text-header-sm">{{ name }}</p>
+      <p v-if="role" class="font-body text-md font-regular leading-[150%]">
+        {{ role }}
+      </p>
+      <p
+        v-for="(paragraph, idx) in bioParagraphs"
+        :key="idx"
+        class="text-body-regular"
+      >
+        {{ paragraph }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/frontend/components/common/cards/JuriCard.vue
+++ b/app/frontend/components/common/cards/JuriCard.vue
@@ -10,12 +10,23 @@ const props = defineProps({
     required: false,
     default: () => [],
   },
+  bioVariant: {
+    type: String,
+    default: "default",
+    validator: (v) => [ "default", "double-spaced" ].includes(v),
+  },
 });
 
 const bioParagraphs = computed(() => {
   if (Array.isArray(props.bio)) return props.bio.filter((p) => p && p.trim());
   return props.bio && props.bio.trim() ? [props.bio] : [];
 });
+
+const bioClass = computed(() =>
+  props.bioVariant === "double-spaced"
+    ? "text-body-regular-double"
+    : "text-body-regular",
+);
 </script>
 
 <template>
@@ -34,7 +45,7 @@ const bioParagraphs = computed(() => {
       <p
         v-for="(paragraph, idx) in bioParagraphs"
         :key="idx"
-        class="text-body-regular"
+        :class="bioClass"
       >
         {{ paragraph }}
       </p>

--- a/app/frontend/components/common/tabs/NavTab.vue
+++ b/app/frontend/components/common/tabs/NavTab.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { Link } from "@inertiajs/vue3";
+
+defineProps({
+  href: { type: String, required: true },
+  active: { type: Boolean, default: false },
+});
+</script>
+
+<template>
+  <Link
+    :href="href"
+    class="flex flex-col flex-1 min-w-0 items-center justify-end h-full gap-150"
+  >
+    <span
+      class="text-body-strong-sm uppercase whitespace-nowrap"
+      :class="active ? 'text-primary' : 'text-secondary-gray'"
+    >
+      <slot />
+    </span>
+    <span
+      class="h-px w-full"
+      :class="active ? 'bg-gradient-to-r from-magenta-600 to-laranja-600' : 'bg-transparent'"
+    ></span>
+  </Link>
+</template>

--- a/app/frontend/pages/Talents/Apresentacao.vue
+++ b/app/frontend/pages/Talents/Apresentacao.vue
@@ -35,7 +35,7 @@ defineProps({
         class="flex flex-col gap-800"
       >
         <SectionHeader>{{ section.titulo }}</SectionHeader>
-        <ul class="flex flex-col gap-400">
+        <ul class="flex flex-col gap-600">
           <li
             v-for="participante in section.participantes"
             :key="participante.name"
@@ -44,6 +44,7 @@ defineProps({
               :photo="participante.photo"
               :name="participante.name"
               :bio="participante.bio"
+              bio-variant="double-spaced"
             />
           </li>
         </ul>

--- a/app/frontend/pages/Talents/Apresentacao.vue
+++ b/app/frontend/pages/Talents/Apresentacao.vue
@@ -1,0 +1,53 @@
+<script setup>
+import JuriCard from "@/components/common/cards/JuriCard.vue";
+import SectionHeader from "@/components/common/SectionHeader.vue";
+import NavTab from "@/components/common/tabs/NavTab.vue";
+import TwContainer from "@/components/layout/TwContainer.vue";
+
+defineProps({
+  pagina: { type: Object, required: true },
+  sections: { type: Array, required: false, default: () => [] },
+  tabs: { type: Array, required: false, default: () => [] },
+});
+</script>
+
+<template>
+  <TwContainer>
+    <div v-if="tabs.length" class="py-800">
+      <nav
+        aria-label="Talents sections"
+        class="flex gap-300 items-center px-400 h-12"
+      >
+        <NavTab
+          v-for="tab in tabs"
+          :key="tab.label"
+          :href="tab.href"
+          :active="tab.active"
+        >
+          {{ tab.label }}
+        </NavTab>
+      </nav>
+    </div>
+    <div class="flex flex-col gap-1600 py-1600">
+      <section
+        v-for="section in sections"
+        :key="section.titulo"
+        class="flex flex-col gap-800"
+      >
+        <SectionHeader>{{ section.titulo }}</SectionHeader>
+        <ul class="flex flex-col gap-400">
+          <li
+            v-for="participante in section.participantes"
+            :key="participante.name"
+          >
+            <JuriCard
+              :photo="participante.photo"
+              :name="participante.name"
+              :bio="participante.bio"
+            />
+          </li>
+        </ul>
+      </section>
+    </div>
+  </TwContainer>
+</template>

--- a/app/frontend/pages/Talents/Apresentacao.vue
+++ b/app/frontend/pages/Talents/Apresentacao.vue
@@ -37,8 +37,8 @@ defineProps({
         <SectionHeader>{{ section.titulo }}</SectionHeader>
         <ul class="flex flex-col gap-600">
           <li
-            v-for="participante in section.participantes"
-            :key="participante.name"
+            v-for="(participante, index) in section.participantes"
+            :key="participante.name + '_' + index"
           >
             <JuriCard
               :photo="participante.photo"

--- a/app/frontend/tests/components/common/SectionHeader.test.js
+++ b/app/frontend/tests/components/common/SectionHeader.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SectionHeader from "@components/common/SectionHeader.vue";
+
+describe("SectionHeader", () => {
+  it("renders slot content inside h2", () => {
+    const wrapper = mount(SectionHeader, {
+      slots: { default: "Coordenadores" },
+    });
+
+    const heading = wrapper.find("h2");
+    expect(heading.exists()).toBe(true);
+    expect(heading.text()).toBe("Coordenadores");
+  });
+
+  it("applies header typography classes", () => {
+    const wrapper = mount(SectionHeader, {
+      slots: { default: "Title" },
+    });
+
+    const heading = wrapper.find("h2");
+    expect(heading.classes()).toContain("text-header-xl");
+    expect(heading.classes()).toContain("text-primary");
+  });
+
+  it("renders gradient divider below heading", () => {
+    const wrapper = mount(SectionHeader, {
+      slots: { default: "Title" },
+    });
+
+    const divider = wrapper.find("div.h-px");
+    expect(divider.exists()).toBe(true);
+    expect(divider.classes()).toContain("bg-gradient-to-r");
+    expect(divider.classes()).toContain("from-magenta-600");
+    expect(divider.classes()).toContain("to-laranja-600");
+  });
+});

--- a/app/frontend/tests/components/common/cards/JuriCard.test.js
+++ b/app/frontend/tests/components/common/cards/JuriCard.test.js
@@ -65,4 +65,23 @@ describe("JuriCard", () => {
 
     expect(wrapper.findAll("p")).toHaveLength(1);
   });
+
+  it("uses default bio class by default", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, bio: "Bio text." },
+    });
+
+    const bioParagraph = wrapper.findAll("p").at(-1);
+    expect(bioParagraph.classes()).toContain("text-body-regular");
+  });
+
+  it("uses double-spaced bio class when bioVariant is 'double-spaced'", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, bio: "Bio text.", bioVariant: "double-spaced" },
+    });
+
+    const bioParagraph = wrapper.findAll("p").at(-1);
+    expect(bioParagraph.classes()).toContain("text-body-regular-double");
+    expect(bioParagraph.classes()).not.toContain("text-body-regular");
+  });
 });

--- a/app/frontend/tests/components/common/cards/JuriCard.test.js
+++ b/app/frontend/tests/components/common/cards/JuriCard.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import JuriCard from "@components/common/cards/JuriCard.vue";
+
+const baseProps = {
+  photo: "https://example.com/mercedes.jpg",
+  name: "Mercedes Morán",
+};
+
+describe("JuriCard", () => {
+  it("renders name and photo", () => {
+    const wrapper = mount(JuriCard, { props: baseProps });
+
+    expect(wrapper.text()).toContain("Mercedes Morán");
+    const img = wrapper.find("img");
+    expect(img.attributes("src")).toBe(baseProps.photo);
+    expect(img.attributes("alt")).toBe(baseProps.name);
+  });
+
+  it("renders role when provided", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, role: "Presidenta do júri" },
+    });
+
+    expect(wrapper.text()).toContain("Presidenta do júri");
+  });
+
+  it("does not render role paragraph when omitted", () => {
+    const wrapper = mount(JuriCard, { props: baseProps });
+
+    expect(wrapper.findAll("p")).toHaveLength(1);
+  });
+
+  it("renders bio passed as string", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, bio: "Atriz argentina." },
+    });
+
+    expect(wrapper.text()).toContain("Atriz argentina.");
+    expect(wrapper.findAll("p")).toHaveLength(2);
+  });
+
+  it("renders bio passed as array of paragraphs", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, bio: [ "Para 1.", "Para 2.", "Para 3." ] },
+    });
+
+    expect(wrapper.text()).toContain("Para 1.");
+    expect(wrapper.text()).toContain("Para 3.");
+    expect(wrapper.findAll("p")).toHaveLength(4);
+  });
+
+  it("does not render bio when empty array", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, bio: [] },
+    });
+
+    expect(wrapper.findAll("p")).toHaveLength(1);
+  });
+
+  it("does not render bio when empty string", () => {
+    const wrapper = mount(JuriCard, {
+      props: { ...baseProps, bio: "" },
+    });
+
+    expect(wrapper.findAll("p")).toHaveLength(1);
+  });
+});

--- a/app/frontend/tests/components/common/tabs/NavTab.test.js
+++ b/app/frontend/tests/components/common/tabs/NavTab.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import NavTab from "@components/common/tabs/NavTab.vue";
+
+const LinkStub = {
+  name: "Link",
+  props: ["href"],
+  template: '<a :href="href"><slot /></a>',
+};
+
+const mountTab = (props = {}, slotContent = "SOBRE") =>
+  mount(NavTab, {
+    props: { href: "/about", ...props },
+    slots: { default: slotContent },
+    global: { stubs: { Link: LinkStub } },
+  });
+
+describe("NavTab", () => {
+  it("renders slot label inside link", () => {
+    const wrapper = mountTab();
+
+    const link = wrapper.find("a");
+    expect(link.exists()).toBe(true);
+    expect(link.attributes("href")).toBe("/about");
+    expect(link.text()).toBe("SOBRE");
+  });
+
+  it("applies active text and gradient indicator when active", () => {
+    const wrapper = mountTab({ active: true });
+
+    const label = wrapper.find("span.text-body-strong-sm");
+    expect(label.classes()).toContain("text-primary");
+
+    const indicator = wrapper.findAll("span").at(-1);
+    expect(indicator.classes()).toContain("bg-gradient-to-r");
+    expect(indicator.classes()).toContain("from-magenta-600");
+    expect(indicator.classes()).toContain("to-laranja-600");
+  });
+
+  it("applies muted text and transparent indicator when inactive", () => {
+    const wrapper = mountTab({ active: false });
+
+    const label = wrapper.find("span.text-body-strong-sm");
+    expect(label.classes()).toContain("text-secondary-gray");
+
+    const indicator = wrapper.findAll("span").at(-1);
+    expect(indicator.classes()).toContain("bg-transparent");
+    expect(indicator.classes()).not.toContain("bg-gradient-to-r");
+  });
+});

--- a/app/services/talents_content_parser.rb
+++ b/app/services/talents_content_parser.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Parses legacy HTML stored in `pagina.conteudo` for the Talents page into
+# structured sections of participants, ready to feed JuriCard props.
+#
+# Expected legacy structure:
+#   <h2>SectionTitle</h2>
+#   <div class="row-fluid">
+#     <div class="span4"><figure><img src="..." alt="..."></figure></div>
+#     <div class="span8"><h3>Name</h3><p>Bio paragraph</p>...</div>
+#   </div>
+class TalentsContentParser
+  class << self
+    def parse(html)
+      new(html).parse
+    end
+  end
+
+  def initialize(html)
+    @html = html.to_s
+  end
+
+  def parse
+    return [] if @html.blank?
+
+    fragment = Nokogiri::HTML::DocumentFragment.parse(@html)
+    sections = []
+    current = nil
+
+    fragment.children.each do |node|
+      next unless node.element?
+
+      case node.name
+      when "h2"
+        current = { titulo: node.text.strip, participantes: [] }
+        sections << current
+      when "div"
+        next unless node["class"]&.include?("row-fluid")
+        next if current.nil?
+        current[:participantes] << extract_participante(node)
+      end
+    end
+
+    sections
+  end
+
+  private
+
+  def extract_participante(node)
+    {
+      name: node.at_css("h3")&.text&.strip,
+      photo: node.at_css("img")&.[]("src"),
+      bio: node.css(".span8 p").map { |p| p.text.strip }.reject(&:blank?)
+    }
+  end
+end

--- a/app/services/talents_tabs.rb
+++ b/app/services/talents_tabs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Builds the Talents section tabs (Sobre / Notícias e Críticas / Programação)
+# shared across the three Talents pages. Hrefs are placeholders ("#") until
+# the destination routes exist.
+class TalentsTabs
+  TABS = [
+    { key: "sobre", path: "#" },
+    { key: "noticias_e_criticas", path: "#" },
+    { key: "programacao", path: "#" }
+  ].freeze
+
+  def self.build(active:)
+    TABS.map do |tab|
+      {
+        label: I18n.t("talents.tabs.#{tab[:key]}"),
+        href: tab[:path],
+        active: tab[:key] === active.to_s
+      }
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,12 @@ en:
     banner_title: "The 26th edition of Festival do Rio is coming!"
     banner_subtitle: "From October 2 to 12, cinema will be under the light of Rio"
 
+  talents:
+    tabs:
+      sobre: "About"
+      noticias_e_criticas: "News & Reviews"
+      programacao: "Schedule"
+
   pelicula:
     sobre_o_filme: "About the movie"
     roteiro: Screenplay

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -3,6 +3,12 @@ pt:
     banner_title: "A 26ª edição do Festival do Rio vem aí!"
     banner_subtitle: "De 2 a 12 de outubro o cinema estará sob a luz do Rio"
 
+  talents:
+    tabs:
+      sobre: "Sobre"
+      noticias_e_criticas: "Notícias e Críticas"
+      programacao: "Programação"
+
   pelicula:
     sobre_o_filme: "Sobre o filme"
     roteiro: Roteiro

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
     resources :peliculas, only: %i[ index show ], param: :permalink
     resources :cinemas, only: :index
     get :equipe, to: "equipe#index", as: :equipe
+    scope :talents do
+      get :apresentacao, to: "talents#participants", as: :talents_members
+    end
   end
 
   get "inertia-example", to: "inertia_example#index"

--- a/test/services/talents_content_parser_test.rb
+++ b/test/services/talents_content_parser_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class TalentsContentParserTest < ActiveSupport::TestCase
+  test "groups participantes by h2 section" do
+    html = <<~HTML
+      <h2>Talents</h2>
+      <div class="row-fluid">
+        <div class="span4"><figure><img src="https://x/a.jpg" alt="A"></figure></div>
+        <div class="span8"><h3>A Name</h3><p>A bio.</p></div>
+      </div>
+      <h2>Mentores</h2>
+      <div class="row-fluid">
+        <div class="span4"><figure><img src="https://x/b.jpg" alt="B"></figure></div>
+        <div class="span8"><h3>B Name</h3><p>B bio.</p></div>
+      </div>
+    HTML
+
+    sections = TalentsContentParser.parse(html)
+
+    assert_equal 2, sections.size
+    assert_equal "Talents", sections[0][:titulo]
+    assert_equal 1, sections[0][:participantes].size
+    assert_equal "A Name", sections[0][:participantes].first[:name]
+    assert_equal "https://x/a.jpg", sections[0][:participantes].first[:photo]
+    assert_equal [ "A bio." ], sections[0][:participantes].first[:bio]
+    assert_equal "Mentores", sections[1][:titulo]
+  end
+
+  test "collects multiple bio paragraphs into array" do
+    html = <<~HTML
+      <h2>Talents</h2>
+      <div class="row-fluid">
+        <div class="span4"><figure><img src="https://x/h.jpg" alt="H"></figure></div>
+        <div class="span8"><h3>H Name</h3><p>Para 1.</p><p>Para 2.</p><p>Para 3.</p></div>
+      </div>
+    HTML
+
+    sections = TalentsContentParser.parse(html)
+    bio = sections[0][:participantes].first[:bio]
+
+    assert_equal [ "Para 1.", "Para 2.", "Para 3." ], bio
+  end
+
+  test "ignores hr separators between row-fluid blocks" do
+    html = <<~HTML
+      <h2>Talents</h2>
+      <div class="row-fluid"><div class="span4"><figure><img src="https://x/a.jpg"></figure></div><div class="span8"><h3>A</h3><p>x</p></div></div>
+      <hr />
+      <div class="row-fluid"><div class="span4"><figure><img src="https://x/b.jpg"></figure></div><div class="span8"><h3>B</h3><p>y</p></div></div>
+    HTML
+
+    sections = TalentsContentParser.parse(html)
+
+    assert_equal 2, sections[0][:participantes].size
+  end
+
+  test "drops blank paragraphs from bio" do
+    html = <<~HTML
+      <h2>Talents</h2>
+      <div class="row-fluid">
+        <div class="span4"><figure><img src="https://x/a.jpg"></figure></div>
+        <div class="span8"><h3>A</h3><p>real bio</p><p>   </p><p></p></div>
+      </div>
+    HTML
+
+    sections = TalentsContentParser.parse(html)
+
+    assert_equal [ "real bio" ], sections[0][:participantes].first[:bio]
+  end
+
+  test "ignores row-fluid before any h2" do
+    html = <<~HTML
+      <div class="row-fluid">
+        <div class="span4"><figure><img src="https://x/a.jpg"></figure></div>
+        <div class="span8"><h3>Orphan</h3><p>x</p></div>
+      </div>
+      <h2>Talents</h2>
+      <div class="row-fluid">
+        <div class="span4"><figure><img src="https://x/b.jpg"></figure></div>
+        <div class="span8"><h3>B</h3><p>y</p></div>
+      </div>
+    HTML
+
+    sections = TalentsContentParser.parse(html)
+
+    assert_equal 1, sections.size
+    assert_equal "B", sections[0][:participantes].first[:name]
+  end
+
+  test "returns empty array for blank input" do
+    assert_equal [], TalentsContentParser.parse(nil)
+    assert_equal [], TalentsContentParser.parse("")
+    assert_equal [], TalentsContentParser.parse("   ")
+  end
+end

--- a/test/services/talents_tabs_test.rb
+++ b/test/services/talents_tabs_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class TalentsTabsTest < ActiveSupport::TestCase
+  test "returns three tabs in fixed order" do
+    tabs = TalentsTabs.build(active: "sobre")
+
+    assert_equal 3, tabs.size
+    assert_equal [ true, false, false ], tabs.map { |t| t[:active] }
+  end
+
+  test "marks notícias active when requested" do
+    tabs = TalentsTabs.build(active: "noticias_e_criticas")
+
+    assert_equal [ false, true, false ], tabs.map { |t| t[:active] }
+  end
+
+  test "marks programação active when requested" do
+    tabs = TalentsTabs.build(active: "programacao")
+
+    assert_equal [ false, false, true ], tabs.map { |t| t[:active] }
+  end
+
+  test "no tab active when key does not match" do
+    tabs = TalentsTabs.build(active: "anything_else")
+
+    assert tabs.none? { |t| t[:active] }
+  end
+
+  test "returns translated labels in pt" do
+    I18n.with_locale(:pt) do
+      tabs = TalentsTabs.build(active: "sobre")
+      assert_equal [ "Sobre", "Notícias e Críticas", "Programação" ], tabs.map { |t| t[:label] }
+    end
+  end
+
+  test "returns translated labels in en" do
+    I18n.with_locale(:en) do
+      tabs = TalentsTabs.build(active: "sobre")
+      assert_equal [ "About", "News & Reviews", "Schedule" ], tabs.map { |t| t[:label] }
+    end
+  end
+
+  test "all tabs use deadlink href until routes are added" do
+    tabs = TalentsTabs.build(active: "sobre")
+
+    assert tabs.all? { |t| t[:href] == "#" }
+  end
+end


### PR DESCRIPTION
## Summary

Renders the Talents Rio "Apresentação" page from legacy HTML (`pagina.conteudo`) into structured cards, adds the shared section navigation, and introduces three reusable presentational components plus two backend services.

- `JuriCard` — photo + name + optional role + bio (string or paragraph array)
- `SectionHeader` — heading with gradient bottom divider
- `NavTab` — Inertia `<Link>` tab with gradient indicator on active
- `TalentsContentParser` — Nokogiri-based parser that groups participants by `<h2>` section and collects multi-paragraph bios
- `TalentsTabs` — translated tab definitions (Sobre / Notícias e Críticas / Programação) ready for the three Talents pages, with `active:` selector

## Context

The legacy app stores the Talents page as raw HTML in `Pagina#conteudo`. This branch extracts that content into props and renders each participant with a design-system card matching the Figma spec, while seeding the shared tab navigation that will also be used by the upcoming "Notícias e Críticas" and "Programação" Talents pages. Tab destinations are deadlinks (`#`) until those routes exist.

Translation strings live under `talents.tabs.*` in `pt.yml` / `en.yml`. Section titles ("Talents", "Mentores", etc.) come straight from the legacy HTML and remain untranslated for now per product call.

## Verification

- [x] Tests pass locally — `bin/rails test` (TalentsContentParser 6, TalentsTabs 7) and `npm test` (JuriCard 7, SectionHeader 3, NavTab 3) all green
- [ ] Manually verified the changes

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->