### PR TITLE
ci: add frontend_test job for vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,28 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  frontend_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install JavaScript dependencies
+        run: |
+          npm ci
+          ROLLUP_VER=$(node -pe "JSON.parse(require('fs').readFileSync('package-lock.json','utf8')).packages['node_modules/rollup'].version")
+          npm install "@rollup/rollup-linux-x64-gnu@${ROLLUP_VER}" --no-save
+
+      - name: Run frontend tests
+        run: npm test -- --run
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Run vitest in parallel with rails test. Skips MySQL/Ruby/Chrome setup since vue tests only need node + jsdom. Pins rollup linux optional dep to match lockfile (npm/cli#4828).

## Summary

<!-- What does this PR do? -->

## Context

<!-- Why is this change needed? Link to issue if applicable -->

## Verification

- [x] Tests pass locally
- [ ] Manually verified the changes

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
