### PR TITLE
feat(talents): add notícias e críticas page + NewsCard component

### DIFF
--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -1,4 +1,9 @@
 class TalentsController < ApplicationController
+  TALENTS_CADERNO_PERMALINK = {
+    pt: "talents-rio",
+    en: "talents-rio"
+  }.freeze
+
   def participants
     @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :apresentacao)
 
@@ -6,6 +11,28 @@ class TalentsController < ApplicationController
       pagina: @pagina,
       sections: TalentsContentParser.parse(@pagina&.conteudo),
       tabs: TalentsTabs.build(active: "sobre")
+    }
+  end
+
+  def news
+    idioma = Idioma.find_by("locale LIKE ?", "#{I18n.locale}%")
+    permalink = TALENTS_CADERNO_PERMALINK[I18n.locale.to_sym] || TALENTS_CADERNO_PERMALINK[:pt]
+    permalink_column = I18n.locale == :pt ? :permalink_pt : :permalink_en
+
+    noticias = Noticia
+      .includes(:caderno)
+      .where(idioma: idioma)
+      .published
+      .joins(:caderno)
+      .where(cadernos: { permalink_column => permalink })
+      .order(created: :desc)
+
+    render inertia: "Talents/NoticiasECriticas", props: {
+      tabs: TalentsTabs.build(active: "noticias_e_criticas"),
+      noticias: noticias.as_json(
+        only: %i[id titulo permalink chamada imagem],
+        methods: [ :caderno_nome, :display_date ]
+      )
     }
   end
 end

--- a/app/frontend/components/common/cards/NewsCard.vue
+++ b/app/frontend/components/common/cards/NewsCard.vue
@@ -1,0 +1,107 @@
+<script setup>
+import { Link } from "@inertiajs/vue3";
+import { computed } from "vue";
+
+const props = defineProps({
+  variant: {
+    type: String,
+    default: "principal",
+    validator: (value) =>
+      ["principal", "secundaria", "horizontal", "horizontal-2"].includes(value),
+  },
+  image: { type: String, required: true },
+  title: { type: String, required: true },
+  date: { type: String, required: true },
+  category: { type: String, required: true },
+  permalink: { type: String, required: true },
+  content: { type: String, required: false, default: "" },
+});
+
+const isHorizontal = computed(() =>
+  ["horizontal", "horizontal-2"].includes(props.variant)
+);
+
+const showContent = computed(() => {
+  if (props.variant === "secundaria") return false;
+  return Boolean(props.content);
+});
+
+const rootClasses = computed(() => {
+  if (isHorizontal.value) {
+    return "flex flex-col md:flex-row gap-200 md:gap-400 md:items-start";
+  }
+  return "flex flex-col gap-200";
+});
+
+const imageWrapperClasses = computed(() => {
+  switch (props.variant) {
+    case "secundaria":
+      return "w-full h-[182px]";
+    case "horizontal":
+      return "w-full md:w-[332px] md:h-[155px] aspect-16/9 md:aspect-auto shrink-0";
+    case "horizontal-2":
+      return "w-full md:flex-1 md:h-[155px] aspect-16/9 md:aspect-auto";
+    default:
+      return "w-full aspect-16/9";
+  }
+});
+
+const textWrapperClasses = computed(() => {
+  if (isHorizontal.value) {
+    return "flex flex-col gap-200 md:flex-1 md:min-w-0";
+  }
+  return "flex flex-col gap-200";
+});
+
+const titleClasses = computed(() => {
+  const base = "text-header-sm text-primary";
+  if (props.variant === "secundaria") return `${base} line-clamp-3`;
+  if (props.variant === "horizontal-2") return `${base} line-clamp-4`;
+  return base;
+});
+
+const contentClasses = computed(() => {
+  const base = "text-body-regular text-primary";
+  if (props.variant === "horizontal-2") {
+    return `${base} truncate`;
+  }
+  return base;
+});
+</script>
+
+<template>
+  <article :class="rootClasses">
+    <Link :href="permalink" :class="imageWrapperClasses" class="block">
+      <img
+        :src="image"
+        :alt="title"
+        class="w-full h-full object-cover rounded-200"
+      />
+    </Link>
+
+    <div :class="textWrapperClasses">
+      <div class="flex gap-200 items-center">
+        <span class="text-overline text-primary whitespace-nowrap">
+          {{ date }}
+        </span>
+        <img
+          src="@assets/icons/divisor.svg"
+          alt=""
+          aria-hidden="true"
+          style="height: 16px"
+        />
+        <span class="text-overline text-primary">
+          {{ category }}
+        </span>
+      </div>
+
+      <h3 :class="titleClasses">
+        <Link :href="permalink">{{ title }}</Link>
+      </h3>
+
+      <p v-if="showContent" :class="contentClasses">
+        {{ content }}
+      </p>
+    </div>
+  </article>
+</template>

--- a/app/frontend/pages/Talents/NoticiasECriticas.vue
+++ b/app/frontend/pages/Talents/NoticiasECriticas.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { computed } from "vue";
+import { Head, usePage } from "@inertiajs/vue3";
+import NewsCard from "@/components/common/cards/NewsCard.vue";
+import NavTab from "@/components/common/tabs/NavTab.vue";
+import TwContainer from "@/components/layout/TwContainer.vue";
+
+const props = defineProps({
+  tabs: { type: Array, required: false, default: () => [] },
+  noticias: { type: Array, required: false, default: () => [] },
+});
+
+const page = usePage();
+
+const NOTICIA_IMAGE_BASE_URL =
+  "https://s3.amazonaws.com/festivaldorio/imagens/noticias/medium2/";
+
+const cards = computed(() =>
+  props.noticias.map((noticia) => ({
+    id: noticia.id,
+    title: noticia.titulo,
+    date: noticia.display_date,
+    category: noticia.caderno_nome,
+    image: `${NOTICIA_IMAGE_BASE_URL}${noticia.imagem}`,
+    permalink: `/${page.props.currentLocale}/noticias/${noticia.permalink}`,
+  }))
+);
+</script>
+
+<template>
+  <Head>
+    <title>Talents Rio - Notícias e Críticas</title>
+  </Head>
+
+  <TwContainer>
+    <div v-if="tabs.length" class="py-800">
+      <nav
+        aria-label="Talents sections"
+        class="flex gap-300 items-center px-400 h-12"
+      >
+        <NavTab
+          v-for="tab in tabs"
+          :key="tab.label"
+          :href="tab.href"
+          :active="tab.active"
+        >
+          {{ tab.label }}
+        </NavTab>
+      </nav>
+    </div>
+
+    <div class="py-1600">
+      <ul
+        v-if="cards.length"
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-800"
+      >
+        <li v-for="card in cards" :key="card.id">
+          <NewsCard
+            variant="secundaria"
+            :image="card.image"
+            :title="card.title"
+            :date="card.date"
+            :category="card.category"
+            :permalink="card.permalink"
+          />
+        </li>
+      </ul>
+    </div>
+  </TwContainer>
+</template>

--- a/app/frontend/tests/components/common/cards/NewsCard.test.js
+++ b/app/frontend/tests/components/common/cards/NewsCard.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import NewsCard from "@components/common/cards/NewsCard.vue";
+
+const baseProps = {
+  image: "https://example.com/foo.jpg",
+  title: "Talents Rio 2025",
+  date: "22.07.2025",
+  category: "TALENTS RIO",
+  permalink: "/pt/noticias/talents-rio-2025",
+};
+
+const stubs = { Link: { template: "<a><slot /></a>", props: ["href"] } };
+
+describe("NewsCard", () => {
+  it("renders image, title, date and category", () => {
+    const wrapper = mount(NewsCard, { props: baseProps, global: { stubs } });
+
+    expect(wrapper.text()).toContain("Talents Rio 2025");
+    expect(wrapper.text()).toContain("22.07.2025");
+    expect(wrapper.text()).toContain("TALENTS RIO");
+    const img = wrapper.findAll("img").find((i) => i.attributes("src") === baseProps.image);
+    expect(img).toBeTruthy();
+    expect(img.attributes("alt")).toBe(baseProps.title);
+  });
+
+  it("renders content paragraph on principal variant", () => {
+    const wrapper = mount(NewsCard, {
+      props: { ...baseProps, content: "Lede here." },
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).toContain("Lede here.");
+  });
+
+  it("does not render content on secundaria variant", () => {
+    const wrapper = mount(NewsCard, {
+      props: { ...baseProps, variant: "secundaria", content: "Hidden lede." },
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).not.toContain("Hidden lede.");
+  });
+
+  it("clamps title on secundaria variant", () => {
+    const wrapper = mount(NewsCard, {
+      props: { ...baseProps, variant: "secundaria" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("h3").classes()).toContain("line-clamp-3");
+  });
+
+  it("clamps title and truncates content on horizontal-2 variant", () => {
+    const wrapper = mount(NewsCard, {
+      props: { ...baseProps, variant: "horizontal-2", content: "Lede." },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("h3").classes()).toContain("line-clamp-4");
+    expect(wrapper.find("p").classes()).toContain("truncate");
+  });
+
+  it("renders content on horizontal variant without truncate", () => {
+    const wrapper = mount(NewsCard, {
+      props: { ...baseProps, variant: "horizontal", content: "Lede." },
+      global: { stubs },
+    });
+
+    const p = wrapper.find("p");
+    expect(p.exists()).toBe(true);
+    expect(p.classes()).not.toContain("truncate");
+  });
+
+  it("does not render paragraph when content empty", () => {
+    const wrapper = mount(NewsCard, {
+      props: { ...baseProps, variant: "principal" },
+      global: { stubs },
+    });
+
+    expect(wrapper.find("p").exists()).toBe(false);
+  });
+
+  it("validates variant prop", () => {
+    const validator = NewsCard.props.variant.validator;
+    expect(validator("principal")).toBe(true);
+    expect(validator("secundaria")).toBe(true);
+    expect(validator("horizontal")).toBe(true);
+    expect(validator("horizontal-2")).toBe(true);
+    expect(validator("bogus")).toBe(false);
+  });
+});

--- a/app/services/talents_tabs.rb
+++ b/app/services/talents_tabs.rb
@@ -5,16 +5,24 @@
 # the destination routes exist.
 class TalentsTabs
   TABS = [
-    { key: "sobre", path: "#" },
-    { key: "noticias_e_criticas", path: "#" },
-    { key: "programacao", path: "#" }
+    { key: "sobre", path_helper: :talents_members_path },
+    { key: "noticias_e_criticas", path_helper: :talents_news_path },
+    { key: "programacao", path_helper: nil }
   ].freeze
 
   def self.build(active:)
+    helpers = Rails.application.routes.url_helpers
+
     TABS.map do |tab|
+      href = if tab[:path_helper] && helpers.respond_to?(tab[:path_helper])
+        helpers.public_send(tab[:path_helper], locale: I18n.locale)
+      else
+        "#"
+      end
+
       {
         label: I18n.t("talents.tabs.#{tab[:key]}"),
-        href: tab[:path],
+        href: href,
         active: tab[:key] === active.to_s
       }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     get :equipe, to: "equipe#index", as: :equipe
     scope :talents do
       get :apresentacao, to: "talents#participants", as: :talents_members
+      get :noticias_e_criticas, to: "talents#news", as: :talents_news
     end
   end
 

--- a/test/controllers/talents_controller_test.rb
+++ b/test/controllers/talents_controller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class TalentsControllerTest < ActionDispatch::IntegrationTest
+  test "news returns inertia response with default locale" do
+    get talents_news_url
+
+    assert_response :success
+    props = inertia_props
+
+    assert_equal "pt", props["currentLocale"]
+    assert props["noticias"].is_a?(Array)
+    assert props["tabs"].is_a?(Array)
+  end
+
+  test "news active tab is noticias_e_criticas" do
+    get talents_news_url(locale: :pt)
+
+    assert_response :success
+    props = inertia_props
+    tabs = props["tabs"]
+
+    active_labels = tabs.select { |t| t["active"] }.map { |t| t["label"] }
+    assert_equal [ "Notícias e Críticas" ], active_labels
+  end
+
+  test "news only includes noticias from talents-rio caderno" do
+    get talents_news_url(locale: :pt)
+
+    assert_response :success
+    props = inertia_props
+
+    assert props["noticias"].any?, "Expected at least one talents noticia"
+    assert props["noticias"].all? { |n| n["caderno_nome"] == "Talents Rio" }
+  end
+
+  test "news excludes noticias from other cadernos" do
+    get talents_news_url(locale: :pt)
+
+    props = inertia_props
+    titles = props["noticias"].map { |n| n["titulo"] }
+
+    assert_not_includes titles, "TEST FELIX TWO titulo"
+  end
+
+  test "news in en locale returns english talents noticias" do
+    get talents_news_url(locale: :en)
+
+    assert_response :success
+    props = inertia_props
+
+    assert_equal "en", props["currentLocale"]
+    assert props["noticias"].is_a?(Array)
+  end
+end

--- a/test/services/talents_tabs_test.rb
+++ b/test/services/talents_tabs_test.rb
@@ -40,9 +40,33 @@ class TalentsTabsTest < ActiveSupport::TestCase
     end
   end
 
-  test "all tabs use deadlink href until routes are added" do
-    tabs = TalentsTabs.build(active: "sobre")
+  test "sobre tab links to talents_members_path" do
+    I18n.with_locale(:pt) do
+      tabs = TalentsTabs.build(active: "sobre")
+      sobre = tabs.find { |t| t[:label] == "Sobre" }
+      assert_equal "/pt/talents/apresentacao", sobre[:href]
+    end
+  end
 
-    assert tabs.all? { |t| t[:href] == "#" }
+  test "noticias_e_criticas tab links to talents_news_path" do
+    I18n.with_locale(:pt) do
+      tabs = TalentsTabs.build(active: "noticias_e_criticas")
+      noticias = tabs.find { |t| t[:label] == "Notícias e Críticas" }
+      assert_equal "/pt/talents/noticias_e_criticas", noticias[:href]
+    end
+  end
+
+  test "programacao tab still uses placeholder until route exists" do
+    tabs = TalentsTabs.build(active: "sobre")
+    programacao = tabs.last
+    assert_equal "#", programacao[:href]
+  end
+
+  test "tab hrefs include current locale" do
+    I18n.with_locale(:en) do
+      tabs = TalentsTabs.build(active: "sobre")
+      sobre = tabs.first
+      assert_equal "/en/talents/apresentacao", sobre[:href]
+    end
   end
 end

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
     alias: {
       "@": resolve(__dirname, "app/frontend"),
       "@components": resolve(__dirname, "app/frontend/components"),
+      "@assets": resolve(__dirname, "app/frontend/assets"),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add `NewsCard` Vue component with the 4 layout variants from Figma (`principal`, `secundaria`, `horizontal`, `horizontal-2`) and Vitest coverage
- Add Talents Rio "Notícias e Críticas" page (`/:locale/talents/noticias_e_criticas`): route, controller action, Inertia page rendering a 3-column grid (1 column on mobile) of `NewsCard` cards
- Wire `TalentsTabs` to real path helpers so the tab navigation links to the actual `apresentacao` and `noticias_e_criticas` routes per locale instead of `#` placeholders
- Add `@assets` alias to `vitest.config.js` so component tests can mount components that import asset paths

## Context

Continuation of the Talents Rio section (RIFF-2). The `Apresentacao` page already existed; this PR introduces the second tab — a listing page that shows all `Noticia` records belonging to the `talents-rio` caderno (108 published rows in `pt` at the time of writing).

Two cards already exist in the codebase (`ArticleCard` for the home and `IndexArticleCard` for the global notícias listing). Their APIs and variant names diverge from the Figma component and refactoring them to fit the new design would force changes on the home and notícias listing call sites. To keep the blast radius small, this PR introduces a brand-new `NewsCard` aligned 1:1 with Figma; migration of the existing cards can happen later if desired.

### Key decisions

- **New component instead of refactoring**: `NewsCard` mirrors Figma variant names (`principal | secundaria | horizontal | horizontal-2`) so design ↔ code parity is preserved and Code Connect mapping later is trivial. `ArticleCard` and `IndexArticleCard` are intentionally untouched.
- **Filter by caderno permalink**: controller filters via `permalink_pt = "talents-rio"` (`permalink_en` mirrors it in the seed data). A `TALENTS_CADERNO_PERMALINK` constant on `TalentsController` makes the slug explicit and locale-aware.
- **Tabs use Rails URL helpers**: `TalentsTabs` now resolves each tab via `path_helper` so adding new Talents pages only requires adding a route and listing the helper. `programacao` keeps `#` until that route exists.
- **Grid layout matches Figma**: `grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-800` — `gap-800 = 2rem = 32px`, exactly the Figma spacing token.

### Files

| Layer | File | Change |
|---|---|---|
| Routes | `config/routes.rb` | new `talents_news` route |
| Controller | `app/controllers/talents_controller.rb` | new `news` action with caderno filter |
| Service | `app/services/talents_tabs.rb` | tabs resolve real paths via helpers |
| View | `app/frontend/pages/Talents/NoticiasECriticas.vue` | new Inertia page |
| Component | `app/frontend/components/common/cards/NewsCard.vue` | new shared card |
| Tests | `test/controllers/talents_controller_test.rb` | new (5 cases) |
| Tests | `test/services/talents_tabs_test.rb` | updated (4 new cases for path helpers) |
| Tests | `app/frontend/tests/components/common/cards/NewsCard.test.js` | new (8 cases) |
| Build | `vitest.config.js` | adds `@assets` alias |

## Verification

- [x] `bin/rails test` — 165 runs, 0 failures, 1 pre-existing skip
- [x] `npx vitest run` — 65 tests passed
- [x] DB sanity-check via `bin/rails runner` confirmed `Caderno talents-rio` exists and returns 108 published `Noticia` rows in `pt`
- [ ] Manually verified the changes in the browser

## Screenshots

<!-- TODO: add desktop + mobile screenshots after manual verification -->