### PR TITLE
refactor(imageable): generalize concern across Pelicula, Noticia, Webdoor, Destaque

### DIFF
--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -30,8 +30,8 @@ class TalentsController < ApplicationController
     render inertia: "Talents/NoticiasECriticas", props: {
       tabs: TalentsTabs.build(active: "noticias_e_criticas"),
       noticias: noticias.as_json(
-        only: %i[id titulo permalink chamada imagem],
-        methods: [ :caderno_nome, :display_date ]
+        only: %i[id titulo permalink chamada],
+        methods: [ :caderno_nome, :display_date, :image_url ]
       )
     }
   end

--- a/app/frontend/pages/Talents/NoticiasECriticas.vue
+++ b/app/frontend/pages/Talents/NoticiasECriticas.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { computed } from "vue";
-import { Head, usePage } from "@inertiajs/vue3";
+import { usePage } from "@inertiajs/vue3";
+import { Head } from "@inertiajs/vue3";
 import NewsCard from "@/components/common/cards/NewsCard.vue";
 import NavTab from "@/components/common/tabs/NavTab.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
@@ -12,19 +12,8 @@ const props = defineProps({
 
 const page = usePage();
 
-const NOTICIA_IMAGE_BASE_URL =
-  "https://s3.amazonaws.com/festivaldorio/imagens/noticias/medium2/";
-
-const cards = computed(() =>
-  props.noticias.map((noticia) => ({
-    id: noticia.id,
-    title: noticia.titulo,
-    date: noticia.display_date,
-    category: noticia.caderno_nome,
-    image: `${NOTICIA_IMAGE_BASE_URL}${noticia.imagem}`,
-    permalink: `/${page.props.currentLocale}/noticias/${noticia.permalink}`,
-  }))
-);
+const noticiaPermalink = (permalink) =>
+  `/${page.props.currentLocale}/noticias/${permalink}`;
 </script>
 
 <template>
@@ -51,17 +40,17 @@ const cards = computed(() =>
 
     <div class="py-1600">
       <ul
-        v-if="cards.length"
+        v-if="noticias.length"
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-800"
       >
-        <li v-for="card in cards" :key="card.id">
+        <li v-for="noticia in noticias" :key="noticia.id">
           <NewsCard
             variant="secundaria"
-            :image="card.image"
-            :title="card.title"
-            :date="card.date"
-            :category="card.category"
-            :permalink="card.permalink"
+            :image="noticia.image_url"
+            :title="noticia.titulo"
+            :date="noticia.display_date"
+            :category="noticia.caderno_nome"
+            :permalink="noticiaPermalink(noticia.permalink)"
           />
         </li>
       </ul>

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -1,61 +1,19 @@
 module Imageable
   extend ActiveSupport::Concern
-  CAROUSEL_IMAGES_AMOUNT = 2
 
-  # Width hints (w descriptors) for responsive srcset — same pattern as PhotoSwipe (sizes + srcset + small src).
-  # Add e.g. [ "large2", 612 ] when that folder exists on the CDN.
-  BANNER_SRCSET_WIDTHS = [
-    [ "large", 300 ],
-    [ "original", 1920 ]
-  ].freeze
+  # Including model MUST define:
+  #   def image_path_prefix = "imagens/noticias"   # no leading/trailing slash
+  #   def image_default_size = "medium2"
 
-  # TODO: RETHINK THIS MAYBE THERE ISN'T TWO IMAGES
-  def carousel_images
-    image_name = imagem
-    return [] if image_name.nil? || image_name.empty?
+  def image_url(size = image_default_size)
+    return nil if imagem.blank?
 
-    (2..CAROUSEL_IMAGES_AMOUNT + 1).to_a.map do |i|
-      image_number = "0#{i}"
-      digits_after_f_regex = /(\w+_f)\d+/
-      image_name = imagem.gsub(digits_after_f_regex, "\\1#{image_number}")
-      {
-        path: imageURL(image_name)
-      }
-    end.compact_blank
+    build_image_url(imagem, size)
   end
 
-  def imageURL(image_name = nil, size = "original")
-    image_name ||= self.imagem
-    image_name = self.imagem_producao if image_name.blank?
-    return if image_name.blank?
+  protected
 
-    build_image_url(image_name, size)
-  end
-
-  # Full-bleed banner: same pattern as PhotoSwipe docs (sizes + srcset + smallest src fallback).
-  def banner_image
-    return unless imagem.present?
-
-    {
-      src: imageURL(nil, "large"),
-      srcset: BANNER_SRCSET_WIDTHS.map { |folder, w| "#{imageURL(nil, folder)} #{w}w" }.join(", "),
-      sizes: "100vw"
-    }
-  end
-
-  # TODO: Define default size for all images in the website
-  def posterImageURL(image_name = nil, size = "large")
-    image_name ||= self.imagem_producao
-    # TODO: CACHE
-    # TODO: IF WE WANT DIFFERENT SIZE?
-    # Rails.cache.fetch("image-for-pelicula-#{id}", expires_in: 12.hours) do
-    build_image_url(image_name, size)
-    # end
-  end
-
-  private
-
-  def build_image_url(img_name, img_size = "large2")
-    "#{ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_ENV")}/#{Edicao.current.descricao}/site/peliculas/#{img_size}/#{img_name}"
+  def build_image_url(img_name, img_size)
+    "#{ENV.fetch("IMAGES_BASE_URL")}/#{image_path_prefix}/#{img_size}/#{img_name}"
   end
 end

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -5,6 +5,14 @@ module Imageable
   #   def image_path_prefix = "imagens/noticias"   # no leading/trailing slash
   #   def image_default_size = "medium2"
 
+  def image_path_prefix
+    raise NotImplementedError, "#{self.class} must implement #image_path_prefix"
+  end
+
+  def image_default_size
+    raise NotImplementedError, "#{self.class} must implement #image_default_size"
+  end
+
   def image_url(size = image_default_size)
     return nil if imagem.blank?
 

--- a/app/models/destaque.rb
+++ b/app/models/destaque.rb
@@ -1,13 +1,11 @@
 class Destaque < ApplicationRecord
+  include Imageable
+
   belongs_to :idioma
   belongs_to :tipo
-  BASE_IMAGE_PATH = "/imagens/destaques/small"
 
   scope :active, -> { where(ativo: 1).order(:ordem) }
 
-  def image_url
-    return "" if imagem.blank?
-
-    "#{ENV.fetch("IMAGES_BASE_URL")}#{BASE_IMAGE_PATH}/#{imagem}"
-  end
+  def image_path_prefix = "imagens/destaques"
+  def image_default_size = "small"
 end

--- a/app/models/noticia.rb
+++ b/app/models/noticia.rb
@@ -1,10 +1,15 @@
 class Noticia < ApplicationRecord
+  include Imageable
+
   belongs_to :caderno
   belongs_to :idioma
 
   validates :data, presence: true
   validates :titulo, presence: true, length: { maximum: 150 }
   validates :permalink, presence: true, length: { maximum: 150 }, uniqueness: true
+
+  def image_path_prefix = "imagens/noticias"
+  def image_default_size = "medium2"
 
   scope :published, -> { where(ativo: true) }
 

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -3,6 +3,11 @@ class Pelicula < ApplicationRecord
   include Rails.application.routes.url_helpers
 
   CAROUSEL_IMAGES_AMOUNT = 3
+  BANNER_SRCSET_WIDTHS = [
+    [ "large", 300 ],
+    [ "original", 1920 ]
+  ].freeze
+
   METHODS_NEEDED = %i[
     display_titulo
     display_sinopse
@@ -101,6 +106,44 @@ class Pelicula < ApplicationRecord
 
   def mostra_tag_class
     mostra.tag_class
+  end
+
+  def image_path_prefix = "#{Edicao.current.descricao}/site/peliculas"
+  def image_default_size = "original"
+
+  def imageURL(image_name = nil, size = "original")
+    image_name ||= imagem
+    image_name = imagem_producao if image_name.blank?
+    return if image_name.blank?
+
+    build_image_url(image_name, size)
+  end
+
+  def posterImageURL(image_name = nil, size = "large")
+    image_name ||= imagem_producao
+    build_image_url(image_name, size)
+  end
+
+  def banner_image
+    return unless imagem.present?
+
+    {
+      src: build_image_url(imagem, "large"),
+      srcset: BANNER_SRCSET_WIDTHS.map { |folder, w| "#{build_image_url(imagem, folder)} #{w}w" }.join(", "),
+      sizes: "100vw"
+    }
+  end
+
+  def carousel_images
+    image_name = imagem
+    return [] if image_name.nil? || image_name.empty?
+
+    (2..CAROUSEL_IMAGES_AMOUNT + 1).map do |i|
+      image_number = "0#{i}"
+      digits_after_f_regex = /(\w+_f)\d+/
+      rotated = imagem.gsub(digits_after_f_regex, "\\1#{image_number}")
+      { path: build_image_url(rotated, "original") }
+    end.compact_blank
   end
 
   def director_image

--- a/app/models/webdoor.rb
+++ b/app/models/webdoor.rb
@@ -1,25 +1,25 @@
 class Webdoor < ApplicationRecord
-  BASE_IMAGE_PATH = "/imagens/webdoors"
+  include Imageable
+
   belongs_to :idioma
 
   scope :published, -> { where(ativo: 1) }
   scope :ordered, -> { published.order(:ordem) }
 
-  def permalink
-    return "" if url.blank?
+  def image_path_prefix = "imagens/webdoors"
+  def image_default_size = "small"
 
-     url.split("/").last
-  end
+  alias_method :desktop_image_url, :image_url
 
   def mobile_image_url
     return "" if imagem_mobile.blank?
 
-    "#{ENV.fetch("IMAGES_BASE_URL")}#{BASE_IMAGE_PATH}/small_mobile/#{imagem_mobile}"
+    build_image_url(imagem_mobile, "small_mobile")
   end
 
-  def desktop_image_url
-    return "" if imagem.blank?
+  def permalink
+    return "" if url.blank?
 
-    "#{ENV.fetch("IMAGES_BASE_URL")}#{BASE_IMAGE_PATH}/small/#{imagem}"
+    url.split("/").last
   end
 end

--- a/test/models/concerns/imageable_test.rb
+++ b/test/models/concerns/imageable_test.rb
@@ -1,96 +1,42 @@
 require "test_helper"
 
 class ImageableTest < ActiveSupport::TestCase
-  class DummyPelicula
+  class DummyModel
     include Imageable
 
-    attr_accessor :imagem, :imagem_producao
+    attr_accessor :imagem
 
-    def initialize(imagem: nil, imagem_producao: nil)
+    def initialize(imagem: nil)
       @imagem = imagem
-      @imagem_producao = imagem_producao
     end
-  end
 
-  TEST_EDICAO = Struct.new(:descricao, :id).new("2024", 12)
+    def image_path_prefix = "imagens/dummy"
+    def image_default_size = "medium"
+  end
 
   def setup
-    @pelicula = DummyPelicula.new(imagem: "test_f01.jpg", imagem_producao: "poster.jpg")
+    @model = DummyModel.new(imagem: "foto.jpg")
   end
 
-  test "imageURL returns correct URL with default parameters" do
+  test "image_url returns correct URL with default size" do
     ENV.stub(:fetch, "https://example.com") do
-      Edicao.stub(:current, TEST_EDICAO) do
-        expected_url = "https://example.com/2024/site/peliculas/original/test_f01.jpg"
-        assert_equal expected_url, @pelicula.imageURL
-      end
+      assert_equal "https://example.com/imagens/dummy/medium/foto.jpg", @model.image_url
     end
   end
 
-  test "imageURL returns correct URL with custom size" do
+  test "image_url accepts custom size" do
     ENV.stub(:fetch, "https://example.com") do
-      Edicao.stub(:current, TEST_EDICAO) do
-        expected_url = "https://example.com/2024/site/peliculas/large/test_f01.jpg"
-        assert_equal expected_url, @pelicula.imageURL(nil, "large")
-      end
+      assert_equal "https://example.com/imagens/dummy/large/foto.jpg", @model.image_url("large")
     end
   end
 
-  test "imageURL falls back to imagem_producao when imagem is blank" do
-    ENV.stub(:fetch, "https://example.com") do
-      Edicao.stub(:current, TEST_EDICAO) do
-        @pelicula.imagem = nil
-        expected_url = "https://example.com/2024/site/peliculas/original/poster.jpg"
-        assert_equal expected_url, @pelicula.imageURL
-      end
-    end
+  test "image_url returns nil when imagem is blank" do
+    @model.imagem = nil
+    assert_nil @model.image_url
   end
 
-  test "imageURL returns nil when both imagem and imagem_producao are blank" do
-    @pelicula.imagem = nil
-    @pelicula.imagem_producao = nil
-    assert_nil @pelicula.imageURL
-  end
-
-  test "banner_image returns src, srcset, and sizes for responsive banner" do
-    ENV.stub(:fetch, "https://example.com") do
-      Edicao.stub(:current, TEST_EDICAO) do
-        banner = @pelicula.banner_image
-        assert_equal "https://example.com/2024/site/peliculas/large/test_f01.jpg", banner[:src]
-        assert_includes banner[:srcset], "https://example.com/2024/site/peliculas/large/test_f01.jpg 300w"
-        assert_includes banner[:srcset], "https://example.com/2024/site/peliculas/original/test_f01.jpg 1920w"
-        assert_equal "100vw", banner[:sizes]
-      end
-    end
-  end
-
-  test "banner_image returns nil when imagem is blank" do
-    @pelicula.imagem = nil
-    assert_nil @pelicula.banner_image
-  end
-
-  test "posterImageURL returns correct poster URL" do
-    ENV.stub(:fetch, "https://example.com") do
-      Edicao.stub(:current, TEST_EDICAO) do
-        expected_url = "https://example.com/2024/site/peliculas/large/poster.jpg"
-        assert_equal expected_url, @pelicula.posterImageURL
-      end
-    end
-  end
-
-  test "carousel_images generates carousel image URLs" do
-    ENV.stub(:fetch, "https://example.com") do
-      Edicao.stub(:current, TEST_EDICAO) do
-        images = @pelicula.carousel_images
-        assert_equal 2, images.length
-        assert_includes images.first[:path], "test_f02.jpg"
-        assert_includes images.last[:path], "test_f03.jpg"
-      end
-    end
-  end
-
-  test "carousel_images returns empty array for blank image" do
-    @pelicula.imagem = ""
-    assert_equal [], @pelicula.carousel_images
+  test "image_url returns nil when imagem is empty string" do
+    @model.imagem = ""
+    assert_nil @model.image_url
   end
 end

--- a/test/models/noticia_test.rb
+++ b/test/models/noticia_test.rb
@@ -45,4 +45,21 @@ class NoticiaTest < ActiveSupport::TestCase
     assert_not duplicate.valid?
     assert duplicate.errors[:permalink].any?
   end
+
+  test "image_url returns full S3 URL for medium2 by default" do
+    base_url = ENV.fetch("IMAGES_BASE_URL")
+    expected = "#{base_url}/imagens/noticias/medium2/#{@valid.imagem}"
+    assert_equal expected, @valid.image_url
+  end
+
+  test "image_url accepts custom size" do
+    base_url = ENV.fetch("IMAGES_BASE_URL")
+    expected = "#{base_url}/imagens/noticias/large/#{@valid.imagem}"
+    assert_equal expected, @valid.image_url("large")
+  end
+
+  test "image_url returns nil when imagem is blank" do
+    @valid.imagem = nil
+    assert_nil @valid.image_url
+  end
 end

--- a/test/models/peliculas_test.rb
+++ b/test/models/peliculas_test.rb
@@ -11,6 +11,48 @@ class PeliculaTest < ActiveSupport::TestCase
     assert_equal expected_url, pelicula.posterImageURL
   end
 
+  test "imageURL returns correct URL with default size" do
+    pelicula = peliculas(:batman)
+    base_url = ENV.fetch("IMAGES_BASE_URL")
+    assert_equal "#{base_url}/2024/site/peliculas/original/batman.jpg", pelicula.imageURL
+  end
+
+  test "imageURL returns correct URL with custom size" do
+    pelicula = peliculas(:batman)
+    base_url = ENV.fetch("IMAGES_BASE_URL")
+    assert_equal "#{base_url}/2024/site/peliculas/large/batman.jpg", pelicula.imageURL(nil, "large")
+  end
+
+  test "imageURL falls back to imagem_producao when imagem is blank" do
+    pelicula = peliculas(:batman)
+    pelicula.imagem = nil
+    base_url = ENV.fetch("IMAGES_BASE_URL")
+    assert_equal "#{base_url}/2024/site/peliculas/original/p01_batman.jpg", pelicula.imageURL
+  end
+
+  test "imageURL returns nil when both imagem and imagem_producao are blank" do
+    pelicula = peliculas(:batman)
+    pelicula.imagem = nil
+    pelicula.imagem_producao = nil
+    assert_nil pelicula.imageURL
+  end
+
+  test "banner_image returns src, srcset and sizes" do
+    pelicula = peliculas(:batman)
+    base_url = ENV.fetch("IMAGES_BASE_URL")
+    banner = pelicula.banner_image
+    assert_equal "#{base_url}/2024/site/peliculas/large/batman.jpg", banner[:src]
+    assert_includes banner[:srcset], "#{base_url}/2024/site/peliculas/large/batman.jpg 300w"
+    assert_includes banner[:srcset], "#{base_url}/2024/site/peliculas/original/batman.jpg 1920w"
+    assert_equal "100vw", banner[:sizes]
+  end
+
+  test "banner_image returns nil when imagem is blank" do
+    pelicula = peliculas(:batman)
+    pelicula.imagem = nil
+    assert_nil pelicula.banner_image
+  end
+
   test "display_titulo returns Portuguese title when locale is pt" do
     pelicula = peliculas(:amor_brasilia)
     I18n.with_locale(:pt) do


### PR DESCRIPTION
## Summary

- Generalize the `Imageable` concern: drop hardcoded `peliculas` S3 path and the direct `Edicao.current` call. Each including model now declares `image_path_prefix` and `image_default_size`; the concern composes URLs as `{IMAGES_BASE_URL}/{prefix}/{size}/{img}`.
- Move pelicula-specific helpers (`imageURL`, `posterImageURL`, `banner_image`, `carousel_images`, `BANNER_SRCSET_WIDTHS`) from the concern back onto the `Pelicula` model.
- Migrate `Noticia`, `Webdoor`, and `Destaque` to `include Imageable`, replacing inline `ENV.fetch("IMAGES_BASE_URL")` string concatenation with the shared `image_url(size)` API.
- Update `TalentsController#news` to serialize `image_url` via `methods:` and drop the `NOTICIA_IMAGE_BASE_URL` constant + `computed cards` indirection from `NoticiasECriticas.vue`.
- Move existing concern tests into `peliculas_test.rb` (covered against the model itself, using fixtures instead of a `DummyPelicula` stub) and add a focused `imageable_test.rb` against a generic `DummyModel`. Add `image_url` tests on `noticia_test.rb`.

## Context

Re-opening this refactor against `main`. PR #120 was accidentally merged into the `riff-2-talents-noticias` feature branch (which had already been merged into main via #119), so the refactor never reached `main`. PR #121 attempted to revert #120 inside that same orphan branch — also a no-op for `main`. This PR brings the work directly to `main` from the still-existing `refactor-imageable` branch.

The original `Imageable` concern was misnamed: it was effectively `PeliculaImageable` — `build_image_url` hardcoded `/{Edicao.current.descricao}/site/peliculas/...` and the public methods only made sense for films. Three other models (`Webdoor`, `Destaque`, the new `Noticia` use case introduced in #119) were each rebuilding the same `ENV.fetch + string concat` pattern with a hardcoded `BASE_IMAGE_PATH`. Centralizing this in the concern eliminates the duplication and gives the frontend a single shape (`model.image_url`) that works for every image-bearing model.

### Decisions

- **Generic concern, not per-model concerns.** All four models share the same env (`IMAGES_BASE_URL=https://s3.amazonaws.com/festivaldorio`) and the same path shape (`{prefix}/{size}/{filename}`). One concern is enough.
- **Models declare path/size as methods, not constants.** This lets `Pelicula` interpolate `Edicao.current.descricao` at call time, while flat models like `Noticia` just return a string literal:
  ```ruby
  def image_path_prefix = "imagens/noticias"
  def image_default_size = "medium2"
  ```
- **Pelicula keeps its compound helpers in the model.** `banner_image`, `posterImageURL`, `carousel_images`, and `imageURL` (with its `imagem` → `imagem_producao` fallback) are pelicula-specific behaviors. The concern only provides primitives (`image_url(size)` and a protected `build_image_url`).
- **Webdoor keeps `desktop_image_url` / `mobile_image_url` as the public API.** Existing `PagesController` serializers already pass these names to the frontend, so `desktop_image_url` is now an `alias_method` of the concern's `image_url`, and `mobile_image_url` calls `build_image_url(imagem_mobile, "small_mobile")` directly.
- **Frontend stops constructing image URLs.** `NoticiasECriticas.vue` reads `noticia.image_url` straight from the props payload — single source of truth in the model.

### Files

| Layer | File | Change |
|---|---|---|
| Concern | `app/models/concerns/imageable.rb` | Generic, model-driven path/size |
| Model | `app/models/pelicula.rb` | Pelicula-specific helpers + concern config |
| Model | `app/models/noticia.rb` | `include Imageable` + path/size |
| Model | `app/models/webdoor.rb` | `include Imageable` + alias + mobile method |
| Model | `app/models/destaque.rb` | `include Imageable` + path/size |
| Controller | `app/controllers/talents_controller.rb` | Serialize `image_url` via methods |
| View | `app/frontend/pages/Talents/NoticiasECriticas.vue` | Drop URL constant + computed cards |
| Tests | `test/models/concerns/imageable_test.rb` | Generic `DummyModel` covering `image_url` primitive |
| Tests | `test/models/peliculas_test.rb` | Added pelicula-specific helpers tests (moved from concern test) |
| Tests | `test/models/noticia_test.rb` | Added `image_url` cases |

### Backward compatibility

No breaking changes for callers:
- `Pelicula#imageURL`, `posterImageURL`, `banner_image`, `carousel_images` — same signatures, same return values.
- `Webdoor#desktop_image_url`, `mobile_image_url` — same names, same return values (`desktop_image_url` is an `alias_method` of `image_url`).
- `Destaque#image_url` — same name, same shape (`{base}/imagens/destaques/small/{filename}`).

## Verification

- [x] `bin/rails test` — 169 runs, 716 assertions, 0 failures, 0 errors, 1 pre-existing skip
- [x] Existing controller integration tests for `pages`, `peliculas`, `noticias`, `talents` continue to pass — confirms backward-compat methods still work end-to-end
- [x] Confirmed in the browser: Talents Rio Notícias e Críticas grid renders all card images via the new `Noticia#image_url` → S3 path

Refs #119, #120, #121.