### PR TITLE
feat(talents): add programação page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,8 @@ class ApplicationController < ActionController::Base
     ENV.fetch("IMAGES_BASE_URL", "DEFINE_BASE_URL_AT_ENV_FILE")
   }
 
+  inertia_share rootUrl: -> { @root_url }
+
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,7 @@ class ApplicationController < ActionController::Base
       "sobre" => [
         { name: I18n.t("navigation.about.name"), path: "", icon: "logoFest" },
         { name: I18n.t("navigation.edicoes_anteriores"), path: edicoes_anteriores_url, icon: "calendar" },
-        { name: I18n.t("navigation.talent_rio"), path: "", icon: "talentPress" },
+        { name: I18n.t("navigation.talent_rio"), path: talents_members_path, icon: "talentPress" },
         { name: I18n.t("navigation.parceiros"), path: "", icon: "handshake" }
       ],
       "midias" => [

--- a/app/controllers/cinemas_controller.rb
+++ b/app/controllers/cinemas_controller.rb
@@ -6,7 +6,6 @@ class CinemasController < ApplicationController
     @salas = Cinema.group_salas(@cinemas)
 
     render inertia: "Cinemas/Index", props: {
-      rootUrl: @root_url,
       cinemas: @salas.as_json,
       crumbs: breadcrumbs(
         [ "", @root_url ],

--- a/app/controllers/edicoes_anteriores_controller.rb
+++ b/app/controllers/edicoes_anteriores_controller.rb
@@ -5,7 +5,6 @@ class EdicoesAnterioresController < ApplicationController
     @edicoes = Edicao.all.order(descricao: :desc).offset(1)
 
     render inertia: "Edicoes/Index", props: {
-      rootUrl: @root_url,
       crumbs: breadcrumbs(
         [ "", @root_url ],
         [ I18n.t("navigation.festival.name"), "#" ],

--- a/app/controllers/equipe_controller.rb
+++ b/app/controllers/equipe_controller.rb
@@ -5,7 +5,6 @@ class EquipeController < ApplicationController
 
   def index
     render inertia: "Equipe/Index", props: {
-      rootUrl: @root_url,
       crumbs: breadcrumbs(
         [ "", @root_url ],
         [ I18n.t("navigation.edition.name", edicao_atual: Edicao.current.descricao), peliculas_path ],

--- a/app/controllers/mostras_controller.rb
+++ b/app/controllers/mostras_controller.rb
@@ -14,7 +14,6 @@ class MostrasController < ApplicationController
     } }
 
     render inertia: "Mostras/Index", props: {
-      rootUrl: @root_url,
       categorias: @categorias.as_json,
       crumbs: breadcrumbs(
         [ "", @root_url ],
@@ -59,7 +58,6 @@ class MostrasController < ApplicationController
     @pagy, @peliculas = pagy_infinite(filtered_relation, current_page, 9)
 
     render inertia: "Mostras/Show", props: {
-      rootUrl: @root_url,
       categoria: params[:category],
       tag_class: @mostras.first.tag_class,
       tabBaseUrl: mostra_path(params[:category]),

--- a/app/controllers/noticias_controller.rb
+++ b/app/controllers/noticias_controller.rb
@@ -27,7 +27,6 @@ class NoticiasController < ApplicationController
     @pagy, @noticias = pagy_infinite(ordered, current_page)
 
     render inertia: "Noticias/Index", props: {
-      rootUrl: @root_url,
       tabBaseUrl: noticias_url,
       dataLabel: I18n.t("filter.date"),
       cadernos: filter_result.cadernos,
@@ -58,7 +57,6 @@ class NoticiasController < ApplicationController
       conteudo: @noticia.conteudo,
       titulo: @noticia.titulo,
       chamada: @noticia.chamada,
-      rootUrl: @root_url,
       breadcrumbs: breadcrumbs(
         [ "Home", @root_url ],
         [ "Notícias", noticias_url ],

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -85,7 +85,6 @@ class PagesController < ApplicationController
       end
 
     render inertia: "HomePage", props: {
-      rootUrl: @root_url,
       quickLinksConfig:,
       noticias:,
       noticasUrl: noticias_url,

--- a/app/controllers/peliculas_controller.rb
+++ b/app/controllers/peliculas_controller.rb
@@ -28,7 +28,6 @@ class PeliculasController < ApplicationController
     @pagy, @peliculas = pagy_infinite(@peliculas, current_page, pagy_limit)
 
     render inertia: "Peliculas/Index", props: {
-      rootUrl: @root_url,
       elements: @peliculas.as_json(
         only: Pelicula::COLUMNS_NEEDED,
         methods: Pelicula::METHODS_NEEDED
@@ -50,7 +49,6 @@ class PeliculasController < ApplicationController
   def show
     @pelicula = Pelicula.includes(:paises, :mostra, programacoes: :cinema).find_by!(edicao_id: Edicao.current.id, permalink: params[:permalink])
     render inertia: "Peliculas/Show", props: {
-      rootUrl: @root_url,
       pelicula: @pelicula.as_json(
         only: Pelicula::COLUMNS_NEEDED,
         methods: Pelicula::METHODS_NEEDED

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -79,7 +79,6 @@ class ProgramsController < ApplicationController
 
     # Build breadcrumbs
     render inertia: "ProgramPage", props: {
-      rootUrl: @root_url,
       tabBaseUrl: program_url,
       elements: @programacoes,
       pagy: @pagy,

--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -8,7 +8,6 @@ class TalentsController < ApplicationController
     @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :apresentacao)
 
     render inertia: "Talents/Apresentacao", props: {
-      pagina: @pagina,
       sections: TalentsContentParser.parse(@pagina&.conteudo),
       tabs: TalentsTabs.build(active: "sobre")
     }
@@ -18,7 +17,6 @@ class TalentsController < ApplicationController
     @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :programacao)
 
     render inertia: "Talents/Programacao", props: {
-      pagina: @pagina,
       sections: TalentsProgramacaoParser.parse(@pagina&.conteudo),
       tabs: TalentsTabs.build(active: "programacao")
     }

--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -10,7 +10,6 @@ class TalentsController < ApplicationController
     @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :apresentacao)
 
     render inertia: "Talents/Apresentacao", props: {
-      rootUrl: @root_url,
       crumbs: talents_crumbs,
       sections: TalentsContentParser.parse(@pagina&.conteudo),
       tabs: TalentsTabs.build(active: "sobre")

--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -1,4 +1,6 @@
 class TalentsController < ApplicationController
+  include BreadcrumbsHelper
+
   TALENTS_CADERNO_PERMALINK = {
     pt: "talents-rio",
     en: "talents-rio"
@@ -8,6 +10,8 @@ class TalentsController < ApplicationController
     @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :apresentacao)
 
     render inertia: "Talents/Apresentacao", props: {
+      rootUrl: @root_url,
+      crumbs: talents_crumbs,
       sections: TalentsContentParser.parse(@pagina&.conteudo),
       tabs: TalentsTabs.build(active: "sobre")
     }
@@ -17,6 +21,7 @@ class TalentsController < ApplicationController
     @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :programacao)
 
     render inertia: "Talents/Programacao", props: {
+      crumbs: talents_crumbs,
       sections: TalentsProgramacaoParser.parse(@pagina&.conteudo),
       tabs: TalentsTabs.build(active: "programacao")
     }
@@ -36,11 +41,22 @@ class TalentsController < ApplicationController
       .order(created: :desc)
 
     render inertia: "Talents/NoticiasECriticas", props: {
+      crumbs: talents_crumbs,
       tabs: TalentsTabs.build(active: "noticias_e_criticas"),
       noticias: noticias.as_json(
         only: %i[id titulo permalink chamada],
         methods: [ :caderno_nome, :display_date, :image_url ]
       )
     }
+  end
+
+  private
+
+  def talents_crumbs
+    breadcrumbs(
+      [ "", @root_url ],
+      [ I18n.t("navigation.festival.name"), "#" ],
+      [ I18n.t("navigation.talent_rio"), talents_members_path ]
+    )
   end
 end

--- a/app/controllers/talents_controller.rb
+++ b/app/controllers/talents_controller.rb
@@ -14,6 +14,16 @@ class TalentsController < ApplicationController
     }
   end
 
+  def programacao
+    @pagina = Pagina.find_by(rota: "/br/talents/", permalink: :programacao)
+
+    render inertia: "Talents/Programacao", props: {
+      pagina: @pagina,
+      sections: TalentsProgramacaoParser.parse(@pagina&.conteudo),
+      tabs: TalentsTabs.build(active: "programacao")
+    }
+  end
+
   def news
     idioma = Idioma.find_by("locale LIKE ?", "#{I18n.locale}%")
     permalink = TALENTS_CADERNO_PERMALINK[I18n.locale.to_sym] || TALENTS_CADERNO_PERMALINK[:pt]

--- a/app/frontend/components/TheLanguageSwitcher.vue
+++ b/app/frontend/components/TheLanguageSwitcher.vue
@@ -1,30 +1,31 @@
 <script setup>
-import { computed } from 'vue'
-import { usePage } from '@inertiajs/vue3'
+import { computed } from "vue";
+import { usePage } from "@inertiajs/vue3";
 
 const LANGUAGES = [
-  { code: 'en', name: 'English' },
-  { code: 'pt', name: 'Portuguese' }
-]
+  { code: "en", name: "English" },
+  { code: "pt", name: "Portuguese" },
+];
 
-const page = usePage()
+const page = usePage();
 
 const currentLocale = computed(() => {
   // locale from ApplicationController
-  return page.props.currentLocale ||
-         document.documentElement.lang ||
-         'pt'
-})
+  return page.props.currentLocale || document.documentElement.lang || "pt";
+});
 
 const switchLanguage = (targetLocale) => {
-  if (targetLocale === currentLocale.value) return
+  if (targetLocale === currentLocale.value) return;
 
-  const newPath = window.location.pathname.replace(new RegExp("/(pt|en)"), `/${targetLocale}`)
-  window.location.href = newPath
-}
+  const newPath = window.location.pathname.replace(
+    new RegExp("/(pt|en)"),
+    `/${targetLocale}`,
+  );
+  window.location.href = newPath;
+};
 
-const isCurrentLanguage = (languageCode) => languageCode === currentLocale.value
-
+const isCurrentLanguage = (languageCode) =>
+  languageCode === currentLocale.value;
 </script>
 
 <template>
@@ -44,7 +45,7 @@ const isCurrentLanguage = (languageCode) => languageCode === currentLocale.value
           'hover:text-neutrals-800 focus:outline-none focus:text-neutrals-900',
           isCurrentLanguage(language.code)
             ? 'text-neutrals-900'
-            : 'text-neutrals-700'
+            : 'text-neutrals-700',
         ]"
         @click="switchLanguage(language.code)"
       >

--- a/app/frontend/components/layout/navbar/NavbarMain.vue
+++ b/app/frontend/components/layout/navbar/NavbarMain.vue
@@ -1,14 +1,14 @@
 <script setup>
+import { usePage } from "@inertiajs/vue3";
 import { BaseButton } from "@/components/common/buttons";
 import MobileMenu from "@/components/layout/navbar/MobileMenu.vue";
 import { IconSearch } from "@/components/common/icons";
 import TheLanguageSwitcher from "@components/TheLanguageSwitcher.vue";
 
-import FestivalLogo from "@assets/logos/logo-nova-full.svg"
+import FestivalLogo from "@assets/logos/logo-nova-full.svg";
 import IconArrowOut from "@/components/common/icons/misc/IconArrowOut.vue";
-const props = defineProps({
-  rootUrl: { type: String, required: true }
-});
+
+const page = usePage();
 </script>
 
 <template>
@@ -21,33 +21,32 @@ const props = defineProps({
     <div
       class="flex flex-col md:flex-row md:gap-400 items-start md:items-center"
     >
-    <a
-      :href="props.rootUrl"
-      class="focus:outline-2 focus:-outline-offset-2 focus:outline-neutrals-300"
-    >
-      <img
-        class="py-200"
-        :src="FestivalLogo"
-        alt="Logo do Festival do Rio"
-        width="300"
-      />
-    </a>
-
-    <div class="hidden md:block">
-      <img src="@assets/icons/divisor.svg" alt="divisor" aria-hidden="true" />
-    </div>
-
-    <div class="festival-dates py-100">
-      <p
-        class="font-body text-neutrals-900 text-sm font-regular leading-[21px] uppercase"
+      <a
+        :href="page.props.rootUrl"
+        class="focus:outline-2 focus:-outline-offset-2 focus:outline-neutrals-300"
       >
-        27th rio de janeiro int'l film festival
-      </p>
-      <p class="text-primary font-body text-md font-bold leading-[22.4px]">
-        2 - 12 OUT 2025
-      </p>
-    </div>
+        <img
+          class="py-200"
+          :src="FestivalLogo"
+          alt="Logo do Festival do Rio"
+          width="300"
+        />
+      </a>
 
+      <div class="hidden md:block">
+        <img src="@assets/icons/divisor.svg" alt="divisor" aria-hidden="true" />
+      </div>
+
+      <div class="festival-dates py-100">
+        <p
+          class="font-body text-neutrals-900 text-sm font-regular leading-[21px] uppercase"
+        >
+          27th rio de janeiro int'l film festival
+        </p>
+        <p class="text-primary font-body text-md font-bold leading-[22.4px]">
+          2 - 12 OUT 2025
+        </p>
+      </div>
     </div>
 
     <!-- MOBILE TOGGLER -->
@@ -57,20 +56,20 @@ const props = defineProps({
       <IconSearch />
       <TheLanguageSwitcher />
 
-<BaseButton
-  as="button"
-  size="sm"
-  class="py-300 px-400 group flex items-center justify-center"
-  variant="rioMarket"
->
-  <span class="transition-all duration-300 group-hover:translate-x-2">
-    RioMarket
-  </span>
+      <BaseButton
+        as="button"
+        size="sm"
+        class="py-300 px-400 group flex items-center justify-center"
+        variant="rioMarket"
+      >
+        <span class="transition-all duration-300 group-hover:translate-x-2">
+          RioMarket
+        </span>
 
-  <IconArrowOut
-    class="ms-150 w-4 h-4 transition-all duration-300 group-hover:opacity-0"
-  />
-</BaseButton>
+        <IconArrowOut
+          class="ms-150 w-4 h-4 transition-all duration-300 group-hover:opacity-0"
+        />
+      </BaseButton>
     </div>
   </nav>
 </template>

--- a/app/frontend/entrypoints/inertia.js
+++ b/app/frontend/entrypoints/inertia.js
@@ -3,32 +3,18 @@ import { createApp, h } from 'vue'
 import PageLayout from '@pages/PageLayout.vue'
 import { FocusTrap } from 'focus-trap-vue'
 
+const wrappedPages = new WeakSet()
+
 createInertiaApp({
-  // Set default page title
-  // see https://inertia-rails.dev/guide/title-and-meta
-  //
-  // title: title => title ? `${title} - App` : 'App',
-
-  // Disable progress bar
-  //
-  // see https://inertia-rails.dev/guide/progress-indicators
-  // progress: false,
-
   resolve: (name) => {
     const pages = import.meta.glob('../pages/**/*.vue', {
       eager: true,
     })
-    // return pages[`../pages/${name}.vue`]
-
-    // To use a default layout, import the Layout component
-    // and use the following lines.
-    // see https://inertia-rails.dev/guide/pages#default-layouts
-    //
     const page = pages[`../pages/${name}.vue`]
-    if (!page.default.__layoutResolved) {
+    if (!wrappedPages.has(page.default)) {
       const childLayout = page.default.layout
       page.default.layout = childLayout ? [PageLayout, childLayout] : PageLayout
-      page.default.__layoutResolved = true
+      wrappedPages.add(page.default)
     }
     return page
   },

--- a/app/frontend/entrypoints/inertia.js
+++ b/app/frontend/entrypoints/inertia.js
@@ -25,7 +25,11 @@ createInertiaApp({
     // see https://inertia-rails.dev/guide/pages#default-layouts
     //
     const page = pages[`../pages/${name}.vue`]
-    page.default.layout = page.default.layout || PageLayout
+    if (!page.default.__layoutResolved) {
+      const childLayout = page.default.layout
+      page.default.layout = childLayout ? [PageLayout, childLayout] : PageLayout
+      page.default.__layoutResolved = true
+    }
     return page
   },
 

--- a/app/frontend/pages/PageLayout.vue
+++ b/app/frontend/pages/PageLayout.vue
@@ -2,22 +2,15 @@
 import NavbarMain from '@/components/layout/navbar/NavbarMain.vue'
 import SponsorHeader from '@/components/layout/headers/SponsorHeader.vue';
 import NavbarSecondary from '@/components/layout/navbar/NavbarSecondary.vue';
-import { usePage } from "@inertiajs/vue3"
 import Flashes from '@/components/shared/Flashes.vue';
 import Footer from '@/components/layout/headers/Footer.vue'
-
-const page = usePage()
-// Define the rootUrl prop to receive data passed from the controller
-const props = defineProps({
-  rootUrl: { type: String, required: true }
-});
 </script>
 
 <template>
   <div class="flex flex-col justify-between min-h-[100vh]">
     <div>
       <SponsorHeader class="bg-azul-400" />
-      <NavbarMain :root-url="props.rootUrl"/>
+      <NavbarMain />
       <NavbarSecondary />
       <Flashes />
 

--- a/app/frontend/pages/Peliculas/Show.vue
+++ b/app/frontend/pages/Peliculas/Show.vue
@@ -36,7 +36,6 @@ const VideoBanner = defineAsyncComponent(
 import { useUpdateWindowWidth } from "@/lib/utils";
 
 const props = defineProps({
-  rootUrl: { type: String, required: true },
   crumbs: { type: Array, required: true, default: () => [] },
   backPath: String,
   pelicula: { type: Object, required: true },

--- a/app/frontend/pages/Talents/Apresentacao.vue
+++ b/app/frontend/pages/Talents/Apresentacao.vue
@@ -1,32 +1,18 @@
 <script setup>
 import JuriCard from "@/components/common/cards/JuriCard.vue";
 import SectionHeader from "@/components/common/SectionHeader.vue";
-import NavTab from "@/components/common/tabs/NavTab.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
+import TalentsLayout from "@/pages/Talents/TalentsLayout.vue";
+
+defineOptions({ layout: TalentsLayout });
 
 defineProps({
   sections: { type: Array, required: false, default: () => [] },
-  tabs: { type: Array, required: false, default: () => [] },
 });
 </script>
 
 <template>
   <TwContainer>
-    <div v-if="tabs.length" class="py-800">
-      <nav
-        aria-label="Talents sections"
-        class="flex gap-300 items-center px-400 h-12"
-      >
-        <NavTab
-          v-for="tab in tabs"
-          :key="tab.label"
-          :href="tab.href"
-          :active="tab.active"
-        >
-          {{ tab.label }}
-        </NavTab>
-      </nav>
-    </div>
     <div class="flex flex-col gap-1600 py-1600">
       <section
         v-for="section in sections"

--- a/app/frontend/pages/Talents/Apresentacao.vue
+++ b/app/frontend/pages/Talents/Apresentacao.vue
@@ -5,7 +5,6 @@ import NavTab from "@/components/common/tabs/NavTab.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
 
 defineProps({
-  pagina: { type: Object, required: true },
   sections: { type: Array, required: false, default: () => [] },
   tabs: { type: Array, required: false, default: () => [] },
 });

--- a/app/frontend/pages/Talents/NoticiasECriticas.vue
+++ b/app/frontend/pages/Talents/NoticiasECriticas.vue
@@ -2,11 +2,12 @@
 import { usePage } from "@inertiajs/vue3";
 import { Head } from "@inertiajs/vue3";
 import NewsCard from "@/components/common/cards/NewsCard.vue";
-import NavTab from "@/components/common/tabs/NavTab.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
+import TalentsLayout from "@/pages/Talents/TalentsLayout.vue";
 
-const props = defineProps({
-  tabs: { type: Array, required: false, default: () => [] },
+defineOptions({ layout: TalentsLayout });
+
+defineProps({
   noticias: { type: Array, required: false, default: () => [] },
 });
 
@@ -22,22 +23,6 @@ const noticiaPermalink = (permalink) =>
   </Head>
 
   <TwContainer>
-    <div v-if="tabs.length" class="py-800">
-      <nav
-        aria-label="Talents sections"
-        class="flex gap-300 items-center px-400 h-12"
-      >
-        <NavTab
-          v-for="tab in tabs"
-          :key="tab.label"
-          :href="tab.href"
-          :active="tab.active"
-        >
-          {{ tab.label }}
-        </NavTab>
-      </nav>
-    </div>
-
     <div class="py-1600">
       <ul
         v-if="noticias.length"

--- a/app/frontend/pages/Talents/Programacao.vue
+++ b/app/frontend/pages/Talents/Programacao.vue
@@ -5,7 +5,6 @@ import SectionHeader from "@/components/common/SectionHeader.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
 
 defineProps({
-  pagina: { type: Object, required: false, default: null },
   sections: { type: Array, required: false, default: () => [] },
   tabs: { type: Array, required: false, default: () => [] },
 });

--- a/app/frontend/pages/Talents/Programacao.vue
+++ b/app/frontend/pages/Talents/Programacao.vue
@@ -46,34 +46,34 @@ defineProps({
 </template>
 
 <style scoped>
-::v-deep(.content p),
-::v-deep(.content span),
-::v-deep(.content li) {
+:deep(.content p),
+:deep(.content span),
+:deep(.content li) {
   font-family: "Inter", sans-serif;
   font-size: 16px;
   font-weight: 400;
   line-height: 2;
 }
 
-::v-deep(.content p:not(:empty):not(:has(img))) {
+:deep(.content p:not(:empty):not(:has(img))) {
   margin-bottom: 1rem;
 }
 
-::v-deep(.content b) {
+:deep(.content b) {
   font-weight: 600;
 }
 
-::v-deep(.content ul) {
+:deep(.content ul) {
   list-style: disc;
   padding-left: 1.5rem;
   margin-bottom: 1rem;
 }
 
-::v-deep(.content a) {
+:deep(.content a) {
   text-decoration: underline;
 }
 
-::v-deep(.content a:hover) {
+:deep(.content a:hover) {
   color: var(--color-vermelho-400);
 }
 </style>

--- a/app/frontend/pages/Talents/Programacao.vue
+++ b/app/frontend/pages/Talents/Programacao.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { Head } from "@inertiajs/vue3";
+import NavTab from "@/components/common/tabs/NavTab.vue";
+import SectionHeader from "@/components/common/SectionHeader.vue";
+import TwContainer from "@/components/layout/TwContainer.vue";
+
+defineProps({
+  pagina: { type: Object, required: false, default: null },
+  sections: { type: Array, required: false, default: () => [] },
+  tabs: { type: Array, required: false, default: () => [] },
+});
+</script>
+
+<template>
+  <Head>
+    <title>Talents Rio - Programação</title>
+  </Head>
+
+  <TwContainer>
+    <div v-if="tabs.length" class="py-800">
+      <nav
+        aria-label="Talents sections"
+        class="flex gap-300 items-center px-400 h-12"
+      >
+        <NavTab
+          v-for="tab in tabs"
+          :key="tab.label"
+          :href="tab.href"
+          :active="tab.active"
+        >
+          {{ tab.label }}
+        </NavTab>
+      </nav>
+    </div>
+
+    <div class="flex flex-col gap-600 py-1600">
+      <section
+        v-for="(section, index) in sections"
+        :key="section.titulo + '_' + index"
+        class="flex flex-col gap-800"
+      >
+        <SectionHeader>{{ section.titulo }}</SectionHeader>
+        <div class="content text-neutrals-900" v-html="section.body_html"></div>
+      </section>
+    </div>
+  </TwContainer>
+</template>
+
+<style scoped>
+::v-deep(.content p),
+::v-deep(.content span),
+::v-deep(.content li) {
+  font-family: "Inter", sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 2;
+}
+
+::v-deep(.content p:not(:empty):not(:has(img))) {
+  margin-bottom: 1rem;
+}
+
+::v-deep(.content b) {
+  font-weight: 600;
+}
+
+::v-deep(.content ul) {
+  list-style: disc;
+  padding-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+::v-deep(.content a) {
+  text-decoration: underline;
+}
+
+::v-deep(.content a:hover) {
+  color: var(--color-vermelho-400);
+}
+</style>

--- a/app/frontend/pages/Talents/Programacao.vue
+++ b/app/frontend/pages/Talents/Programacao.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { Head } from "@inertiajs/vue3";
-import NavTab from "@/components/common/tabs/NavTab.vue";
 import SectionHeader from "@/components/common/SectionHeader.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
+import TalentsLayout from "@/pages/Talents/TalentsLayout.vue";
+
+defineOptions({ layout: TalentsLayout });
 
 defineProps({
   sections: { type: Array, required: false, default: () => [] },
-  tabs: { type: Array, required: false, default: () => [] },
 });
 </script>
 
@@ -16,22 +17,6 @@ defineProps({
   </Head>
 
   <TwContainer>
-    <div v-if="tabs.length" class="py-800">
-      <nav
-        aria-label="Talents sections"
-        class="flex gap-300 items-center px-400 h-12"
-      >
-        <NavTab
-          v-for="tab in tabs"
-          :key="tab.label"
-          :href="tab.href"
-          :active="tab.active"
-        >
-          {{ tab.label }}
-        </NavTab>
-      </nav>
-    </div>
-
     <div class="flex flex-col gap-600 py-1600">
       <section
         v-for="(section, index) in sections"

--- a/app/frontend/pages/Talents/TalentsLayout.vue
+++ b/app/frontend/pages/Talents/TalentsLayout.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { computed } from "vue";
+import { usePage } from "@inertiajs/vue3";
+import Breadcrumb from "@/components/common/Breadcrumb.vue";
+import NavTab from "@/components/common/tabs/NavTab.vue";
+import MenuContext from "@/components/layout/navbar/MenuContext.vue";
+import TwContainer from "@/components/layout/TwContainer.vue";
+
+const page = usePage();
+const crumbs = computed(() => page.props.crumbs || []);
+const tabs = computed(() => page.props.tabs || []);
+</script>
+
+<template>
+  <TwContainer>
+    <Breadcrumb :crumbs="crumbs" />
+  </TwContainer>
+  <MenuContext nav="sobre" />
+  <hr class="text-neutrals-300" />
+
+  <TwContainer>
+    <div v-if="tabs.length" class="py-800">
+      <nav
+        aria-label="Talents sections"
+        class="flex gap-300 items-center px-400 h-12"
+      >
+        <NavTab
+          v-for="tab in tabs"
+          :key="tab.label"
+          :href="tab.href"
+          :active="tab.active"
+        >
+          {{ tab.label }}
+        </NavTab>
+      </nav>
+    </div>
+  </TwContainer>
+  <slot />
+</template>

--- a/app/services/talents_programacao_parser.rb
+++ b/app/services/talents_programacao_parser.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Parses legacy HTML stored in `pagina.conteudo` for the Talents Programação
+# page into sections grouped by day.
+#
+# Expected legacy structure:
+#   <h3>DATE TITLE</h3>
+#   <hr>
+#   <p>...</p><ul>...</ul>...
+#   <h3>NEXT DATE</h3>
+#   ...
+class TalentsProgramacaoParser
+  class << self
+    def parse(html)
+      new(html).parse
+    end
+  end
+
+  def initialize(html)
+    @html = html.to_s
+  end
+
+  def parse
+    return [] if @html.blank?
+
+    fragment = Nokogiri::HTML::DocumentFragment.parse(@html)
+    sections = []
+    current = nil
+
+    fragment.children.each do |node|
+      next if node.text? && node.text.strip.empty?
+
+      if node.element? && node.name == "h3"
+        current = { titulo: node.text.strip, body_html: +"" }
+        sections << current
+      elsif node.element? && node.name == "hr"
+        next
+      elsif current
+        current[:body_html] << node.to_html
+      end
+    end
+
+    sections
+  end
+end

--- a/app/services/talents_tabs.rb
+++ b/app/services/talents_tabs.rb
@@ -7,7 +7,7 @@ class TalentsTabs
   TABS = [
     { key: "sobre", path_helper: :talents_members_path },
     { key: "noticias_e_criticas", path_helper: :talents_news_path },
-    { key: "programacao", path_helper: nil }
+    { key: "programacao", path_helper: :talents_programacao_path }
   ].freeze
 
   def self.build(active:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     scope :talents do
       get :apresentacao, to: "talents#participants", as: :talents_members
       get :noticias_e_criticas, to: "talents#news", as: :talents_news
+      get :programacao, to: "talents#programacao", as: :talents_programacao
     end
   end
 

--- a/test/controllers/talents_controller_test.rb
+++ b/test/controllers/talents_controller_test.rb
@@ -51,4 +51,23 @@ class TalentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "en", props["currentLocale"]
     assert props["noticias"].is_a?(Array)
   end
+
+  test "programacao returns inertia response with sections and tabs" do
+    get talents_programacao_url(locale: :pt)
+
+    assert_response :success
+    props = inertia_props
+
+    assert props["sections"].is_a?(Array)
+    assert props["tabs"].is_a?(Array)
+  end
+
+  test "programacao active tab is programacao" do
+    get talents_programacao_url(locale: :pt)
+
+    props = inertia_props
+    active_labels = props["tabs"].select { |t| t["active"] }.map { |t| t["label"] }
+
+    assert_equal [ "Programação" ], active_labels
+  end
 end

--- a/test/services/talents_programacao_parser_test.rb
+++ b/test/services/talents_programacao_parser_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class TalentsProgramacaoParserTest < ActiveSupport::TestCase
+  test "groups content by h3 headings" do
+    html = <<~HTML
+      <h3>DOMINGO, 5 DE OUTUBRO</h3><hr>
+      <p><b>14:30 - Boas vindas</b></p>
+      <ul><li>Pedro</li></ul>
+      <h3>SEGUNDA-FEIRA, 6 DE OUTUBRO</h3><hr>
+      <p><b>09:45 - Painel</b></p>
+    HTML
+
+    sections = TalentsProgramacaoParser.parse(html)
+
+    assert_equal 2, sections.size
+    assert_equal "DOMINGO, 5 DE OUTUBRO", sections[0][:titulo]
+    assert_equal "SEGUNDA-FEIRA, 6 DE OUTUBRO", sections[1][:titulo]
+  end
+
+  test "section body_html preserves inner markup" do
+    html = <<~HTML
+      <h3>DIA 1</h3><hr>
+      <p><b>10h</b> Atividade</p>
+      <ul><li>Pessoa A</li><li>Pessoa B</li></ul>
+    HTML
+
+    body = TalentsProgramacaoParser.parse(html).first[:body_html]
+
+    assert_includes body, "<p><b>10h</b> Atividade</p>"
+    assert_includes body, "<li>Pessoa A</li>"
+    assert_includes body, "<li>Pessoa B</li>"
+    assert_includes body, "<ul"
+  end
+
+  test "skips hr separator between heading and body" do
+    html = "<h3>DIA 1</h3><hr><p>conteudo</p>"
+
+    body = TalentsProgramacaoParser.parse(html).first[:body_html]
+
+    assert_not_includes body, "<hr"
+    assert_includes body, "<p>conteudo</p>"
+  end
+
+  test "ignores content before any h3" do
+    html = "<p>orfao</p><h3>DIA 1</h3><hr><p>real</p>"
+
+    sections = TalentsProgramacaoParser.parse(html)
+
+    assert_equal 1, sections.size
+    assert_not_includes sections[0][:body_html], "orfao"
+    assert_includes sections[0][:body_html], "real"
+  end
+
+  test "returns empty array for blank input" do
+    assert_equal [], TalentsProgramacaoParser.parse(nil)
+    assert_equal [], TalentsProgramacaoParser.parse("")
+    assert_equal [], TalentsProgramacaoParser.parse("   ")
+  end
+end

--- a/test/services/talents_tabs_test.rb
+++ b/test/services/talents_tabs_test.rb
@@ -56,10 +56,12 @@ class TalentsTabsTest < ActiveSupport::TestCase
     end
   end
 
-  test "programacao tab still uses placeholder until route exists" do
-    tabs = TalentsTabs.build(active: "sobre")
-    programacao = tabs.last
-    assert_equal "#", programacao[:href]
+  test "programacao tab links to talents_programacao_path" do
+    I18n.with_locale(:pt) do
+      tabs = TalentsTabs.build(active: "programacao")
+      programacao = tabs.last
+      assert_equal "/pt/talents/programacao", programacao[:href]
+    end
   end
 
   test "tab hrefs include current locale" do


### PR DESCRIPTION
## Summary

- Extract `TalentsLayout` with Breadcrumb + MenuContext + tabs nav shared across all 3 Talents pages
- Fix missing Breadcrumb on `Programacao` and `NoticiasECriticas`
- `inertia.js`: WeakSet guard wraps `[PageLayout, childLayout]` idempotently — avoids nested-array bug on re-resolve
- `ApplicationController`: `inertia_share rootUrl` removes per-action duplication across 9 controllers
- `NavbarMain`: reads `rootUrl` from `usePage()` directly, drops prop
- `PageLayout`: drops `rootUrl` prop and pass-through

## Test plan

- [x] `/pt/talents/apresentacao` — Breadcrumb, MenuContext, tabs aparecem
- [x] `/pt/talents/programacao` — idem (antes não tinha Breadcrumb)
- [x] `/pt/talents/noticias-e-criticas` — idem
- [x] Logo na NavbarMain aponta pro rootUrl correto
- [x] Navegação entre páginas não duplica layout