### PR TITLE
fix(heroku): deploy fixes - remove release, npmrc, use db:migrate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-os=any
-cpu=any
-libc=any

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rails assets:precompile
+release: bundle exec rails db:migrate


### PR DESCRIPTION
Fixes from troubleshooting Heroku deploy:
  - Remove .npmrc (npm detect platform)
  - Procfile: remove assets:precompile from release (OOM)
  - Procfile: remove release entirely (no migrations needed, dump-loaded DB)