### PR TITLE
RIFF-52: edições anteriores - mostras index

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,10 +107,10 @@ class ApplicationController < ActionController::Base
 
   def edicoes_anteriores_menu_context(edicao)
     [
-      { name: "Mostras", path: edicao_anterior_mostras_path(edicao), icon: "grid" },
-      { name: "Filmes", path: edicao_anterior_filmes_path(edicao), icon: "film" },
-      { name: "Notícias", path: edicao_anterior_noticias_path(edicao), icon: "newspaper" },
-      { name: "Júri/Premiados", path: "#", icon: "trophy" }
+      { name: I18n.t("navigation.mostras"), path: edicao_anterior_mostras_path(edicao), icon: "grid" },
+      { name: I18n.t("navigation.todos_os_filmes"), path: edicao_anterior_filmes_path(edicao), icon: "film" },
+      { name: I18n.t("navigation.todas_as_noticias"), path: edicao_anterior_noticias_path(edicao), icon: "newspaper" },
+      { name: I18n.t("navigation.juri"), path: "#", icon: "trophy" }
     ]
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,8 +100,18 @@ class ApplicationController < ActionController::Base
       "midias" => [
         { name: I18n.t("navigation.media.fotos_e_videos"), path: "", icon: "image" },
         { name: I18n.t("navigation.media.impressos"), path: "", icon: "book" }
-      ]
+      ],
+      "edicoes_anteriores" => []
     }
+  end
+
+  def edicoes_anteriores_menu_context(edicao)
+    [
+      { name: "Mostras", path: edicao_anterior_mostras_path(edicao), icon: "grid" },
+      { name: "Filmes", path: edicao_anterior_filmes_path(edicao), icon: "film" },
+      { name: "Notícias", path: edicao_anterior_noticias_path(edicao), icon: "newspaper" },
+      { name: "Júri/Premiados", path: "#", icon: "trophy" }
+    ]
   end
 
   def set_secondary_items

--- a/app/controllers/edicoes/mostras_controller.rb
+++ b/app/controllers/edicoes/mostras_controller.rb
@@ -13,11 +13,12 @@ class Edicoes::MostrasController < ApplicationController
       mostraImageURL: mostras.first.peliculas.sample&.imageURL
     } }
     render inertia: "Edicoes/Mostras", props: {
-      edicao: @edicao.as_json(only: %i[id descricao]).merge(cartazURL: @edicao.image_url),
+      edicao: @edicao.as_json(only: %i[id descricao], methods: %i[cartazURL]),
       categorias: @categorias.as_json,
       menuContext: set_menu_context.merge(
         "edicoes_anteriores" => edicoes_anteriores_menu_context(@edicao)
-      )
+      ),
+      fallBackUrl: edicoes_anteriores_path
     }
   end
 

--- a/app/controllers/edicoes/mostras_controller.rb
+++ b/app/controllers/edicoes/mostras_controller.rb
@@ -1,0 +1,29 @@
+class Edicoes::MostrasController < ApplicationController
+  include BreadcrumbsHelper
+  before_action :set_edicao
+
+  def index
+    ultima_importacao_id = Importacao.where(edicao_id: @edicao.id).order(created: :desc).pick(:id)
+    @mostras = Mostra.includes(:peliculas).where(importacao_id: ultima_importacao_id).group_by(&:display_name)
+
+    @categorias = @mostras.map { |categoria, mostras| {
+      name: categoria,
+      class: mostras.first.tag_class,
+      path: mostra_path(categoria),
+      mostraImageURL: mostras.first.peliculas.sample&.imageURL
+    } }
+    render inertia: "Edicoes/Mostras", props: {
+      edicao: @edicao.as_json(only: %i[id descricao]).merge(cartazURL: @edicao.image_url),
+      categorias: @categorias.as_json,
+      menuContext: set_menu_context.merge(
+        "edicoes_anteriores" => edicoes_anteriores_menu_context(@edicao)
+      )
+    }
+  end
+
+  private
+
+  def set_edicao
+    @edicao = Edicao.find(params[:edicao_anterior_id])
+  end
+end

--- a/app/controllers/edicoes_anteriores_controller.rb
+++ b/app/controllers/edicoes_anteriores_controller.rb
@@ -12,7 +12,7 @@ class EdicoesAnterioresController < ApplicationController
       ),
       edicoes: @edicoes.as_json(
                 only: %i[id descricao cartaz],
-                methods: []
+                methods: [ :cartazURL ]
               )
     }
   end

--- a/app/frontend/components/common/EdicaoHeader.vue
+++ b/app/frontend/components/common/EdicaoHeader.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { router } from "@inertiajs/vue3";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import PhotoSwipeLightbox from "photoswipe/lightbox";
 import "photoswipe/dist/photoswipe.css";
@@ -7,9 +8,12 @@ import IconChevronLeft from "@/components/common/icons/navigation/IconChevronLef
 
 const props = defineProps({
   edicao: { type: Object, required: true },
+  fallBackUrl: { type: String, required: true },
 });
 
-const goBack = () => window.history.back();
+const goBack = () => {
+  window.history.state?.url ? router.back() : router.visit(props.fallBackUrl);
+};
 
 const cartazDims = ref(null);
 

--- a/app/frontend/components/common/EdicaoHeader.vue
+++ b/app/frontend/components/common/EdicaoHeader.vue
@@ -1,0 +1,61 @@
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import PhotoSwipeLightbox from "photoswipe/lightbox";
+import "photoswipe/dist/photoswipe.css";
+import ButtonText from "@/components/common/buttons/ButtonText.vue";
+import IconChevronLeft from "@/components/common/icons/navigation/IconChevronLeft.vue";
+
+const props = defineProps({
+  edicao: { type: Object, required: true },
+});
+
+const goBack = () => window.history.back();
+
+const cartazDims = ref(null);
+
+const onCartazLoad = (e) => {
+  cartazDims.value = {
+    width: e.target.naturalWidth,
+    height: e.target.naturalHeight,
+  };
+};
+
+const lightbox = new PhotoSwipeLightbox({
+  gallery: "#edicao-header-cartaz",
+  children: "a",
+  pswpModule: () => import("photoswipe"),
+});
+
+onMounted(() => lightbox.init());
+onBeforeUnmount(() => lightbox.destroy());
+</script>
+
+<template>
+  <div class="flex items-center justify-between py-300">
+    <ButtonText tag="button" text="Voltar" @click="goBack">
+      <template #icon>
+        <IconChevronLeft width="16" height="16" class="mr-200" />
+      </template>
+    </ButtonText>
+
+    <div id="edicao-header-cartaz" class="flex items-end gap-800 pt-600">
+      <p class="text-header-xl text-neutrals-900">
+        {{ props.edicao.descricao }}
+      </p>
+      <a
+        v-if="props.edicao.cartazURL"
+        :href="props.edicao.cartazURL"
+        :data-pswp-width="cartazDims?.width"
+        :data-pswp-height="cartazDims?.height"
+        class="cursor-zoom-in outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      >
+        <img
+          :src="props.edicao.cartazURL"
+          :alt="`Cartaz ${props.edicao.descricao}`"
+          class="h-[98px] w-[68px] object-cover rounded-100 pointer-events-none"
+          @load="onCartazLoad"
+        />
+      </a>
+    </div>
+  </div>
+</template>

--- a/app/frontend/components/common/cards/Cartaz.vue
+++ b/app/frontend/components/common/cards/Cartaz.vue
@@ -1,50 +1,57 @@
 <script setup>
 const props = defineProps({
   cartaz: { type: String, required: true },
-  descricao: { type: String, required: true}
-})
+  descricao: { type: String, required: true },
+});
 </script>
 
 <template>
-  <li>
-    <img :src="props.cartaz" :alt="`Poster do Festival de ${props.descricao}`">
+  <div>
+    <img
+      :src="props.cartaz"
+      :alt="`Poster do Festival de ${props.descricao}`"
+    />
     <p class="p-400">
       {{ props.descricao }}
       <!-- <hr> -->
     </p>
-  </li>
+  </div>
 </template>
 
 <style scoped>
-  li {
-    position: relative;
-  }
+div {
+  position: relative;
+}
 
-  li::after {
-    position: absolute;
-    content:"";
-    height:100%;
-    width:100%;
-    top:0;
-    left:0;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0.30) 73.08%, rgba(0, 0, 0, 0.64) 100%);
-  }
+div::after {
+  position: absolute;
+  content: "";
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.3) 73.08%,
+    rgba(0, 0, 0, 0.64) 100%
+  );
+}
 
-  p {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    color: white;
-    z-index: 1;
-    width: 100%;
-  }
+p {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  color: white;
+  z-index: 1;
+  width: 100%;
+}
 
-  img {
-    width: 100%;
-    height: auto;
-  }
+img {
+  width: 100%;
+  height: auto;
+}
 
-  /* hr {
+/* hr {
     visibility: hidden;
     transition: visibility 0.2s ease, margin-top .3s ease
   }

--- a/app/frontend/components/common/icons/misc/IconFilm.vue
+++ b/app/frontend/components/common/icons/misc/IconFilm.vue
@@ -1,0 +1,22 @@
+<script setup>
+import { BaseIcon } from "@components/common/icons";
+const props = defineProps({
+  color: { type: String, default: 'text-neutrals-900' },
+  active: { type: Boolean, default: false },
+});
+</script>
+
+<template>
+  <BaseIcon viewBox="0 0 20 20" :active="active" :className="props.color">
+    <template #default="{ fill }">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M2 4.5A2.5 2.5 0 0 1 4.5 2h11A2.5 2.5 0 0 1 18 4.5v11A2.5 2.5 0 0 1 15.5 18h-11A2.5 2.5 0 0 1 2 15.5v-11ZM4 5.75c0-.414.336-.75.75-.75h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 4 5.75Zm0 4c0-.414.336-.75.75-.75h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 4 9.75Zm0 4c0-.414.336-.75.75-.75h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 4 13.75Zm10.25-.75a.75.75 0 0 0 0 1.5h.5a.75.75 0 0 0 0-1.5h-.5Zm0-4a.75.75 0 0 0 0 1.5h.5a.75.75 0 0 0 0-1.5h-.5Zm0-4a.75.75 0 0 0 0 1.5h.5a.75.75 0 0 0 0-1.5h-.5ZM7.25 5A.75.75 0 0 0 6.5 5.75v8.5c0 .414.336.75.75.75h5.5a.75.75 0 0 0 .75-.75v-8.5A.75.75 0 0 0 12.75 5h-5.5Z"
+        :fill="fill"
+      />
+    </template>
+  </BaseIcon>
+</template>
+
+<style scoped></style>

--- a/app/frontend/components/common/icons/misc/IconNewspaper.vue
+++ b/app/frontend/components/common/icons/misc/IconNewspaper.vue
@@ -1,0 +1,22 @@
+<script setup>
+import { BaseIcon } from "@components/common/icons";
+const props = defineProps({
+  color: { type: String, default: 'text-neutrals-900' },
+  active: { type: Boolean, default: false },
+});
+</script>
+
+<template>
+  <BaseIcon viewBox="0 0 20 20" :active="active" :className="props.color">
+    <template #default="{ fill }">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5V4h1.5A2.5 2.5 0 0 1 18 6.5v9a2.5 2.5 0 0 1-2.5 2.5H4a2 2 0 0 1-2-2V3.5ZM3.5 3a.5.5 0 0 0-.5.5V16a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5V3.5a.5.5 0 0 0-.5-.5h-9Zm11 2.5H14v10.028A1.5 1.5 0 0 0 15.5 17a1 1 0 0 0 1-1V6.5a1 1 0 0 0-1-1ZM5 5.75A.75.75 0 0 1 5.75 5h4.5a.75.75 0 0 1 0 1.5h-4.5A.75.75 0 0 1 5 5.75ZM5.75 8A.75.75 0 0 0 5 8.75v2.5c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-2.5A.75.75 0 0 0 10.25 8h-4.5ZM5 13.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Z"
+        :fill="fill"
+      />
+    </template>
+  </BaseIcon>
+</template>
+
+<style scoped></style>

--- a/app/frontend/components/layout/navbar/MenuContext.vue
+++ b/app/frontend/components/layout/navbar/MenuContext.vue
@@ -30,14 +30,17 @@ const loaders = {
   talentPress: () => import('@/components/common/icons/misc/IconTalentPress.vue'),
   handshake: () => import('@/components/common/icons/misc/IconHandshake.vue'),
   image: () => import('@/components/common/icons/misc/IconImage.vue'),
-  book: () => import('@/components/common/icons/misc/IconBook.vue')
+  book: () => import('@/components/common/icons/misc/IconBook.vue'),
+  film: () => import('@/components/common/icons/misc/IconFilm.vue'),
+  newspaper: () => import('@/components/common/icons/misc/IconNewspaper.vue'),
 }
 
 const loadersPerNav = {
   programacao: ["program", "newUser", "change", "ticket"],
   edicao: ["program", "grid", "pin", "trophy", "people"],
   sobre: ["logoFest", "calendar", "talentPress", "handshake"],
-  midias: ["image", "book"]
+  midias: ["image", "book"],
+  edicoes_anteriores: ["grid", "film", "newspaper", "trophy"],
 }
 
 const cache = new Map()

--- a/app/frontend/pages/Edicoes/Index.vue
+++ b/app/frontend/pages/Edicoes/Index.vue
@@ -3,30 +3,31 @@ import MenuContext from "@/components/layout/navbar/MenuContext.vue";
 import TwContainer from "@/components/layout/TwContainer.vue";
 import Cartaz from "@/components/common/cards/Cartaz.vue";
 import Breadcrumb from "@/components/common/Breadcrumb.vue";
+import { Link } from "@inertiajs/vue3";
 
 const props = defineProps({
-  edicoes: { type: Array, default: () => []},
-  crumbs: { type: Array, required: true}
-})
-
+  edicoes: { type: Array, default: () => [] },
+  crumbs: { type: Array, required: true },
+});
 </script>
 
 <template>
   <TwContainer>
     <Breadcrumb :crumbs="props.crumbs" />
   </TwContainer>
-  <MenuContext
-    nav="sobre"
-  />
-  <hr class="text-neutrals-300">
+  <MenuContext nav="sobre" />
+  <hr class="text-neutrals-300" />
 
   <TwContainer>
     <ul class="grid grid-cols-2 lg:grid-cols-6 py-1200 gap-800">
-      <Cartaz
-        v-for="edicao in props.edicoes" :key="edicao.id"
-        :cartaz="`https://s3.amazonaws.com/festivaldorio/imagens/edicoes/small/${edicao.cartaz}`"
-        :descricao="edicao.descricao"
-      />
+      <li v-for="edicao in props.edicoes" :key="edicao.id">
+        <Link :href="`/edicoes_anteriores/${edicao.id}/mostras`" prefetch>
+          <Cartaz
+            :cartaz="`https://s3.amazonaws.com/festivaldorio/imagens/edicoes/small/${edicao.cartaz}`"
+            :descricao="edicao.descricao"
+          />
+        </Link>
+      </li>
     </ul>
   </TwContainer>
 </template>

--- a/app/frontend/pages/Edicoes/Index.vue
+++ b/app/frontend/pages/Edicoes/Index.vue
@@ -22,10 +22,7 @@ const props = defineProps({
     <ul class="grid grid-cols-2 lg:grid-cols-6 py-1200 gap-800">
       <li v-for="edicao in props.edicoes" :key="edicao.id">
         <Link :href="`/edicoes_anteriores/${edicao.id}/mostras`" prefetch>
-          <Cartaz
-            :cartaz="`https://s3.amazonaws.com/festivaldorio/imagens/edicoes/small/${edicao.cartaz}`"
-            :descricao="edicao.descricao"
-          />
+          <Cartaz :cartaz="edicao.cartazURL" :descricao="edicao.descricao" />
         </Link>
       </li>
     </ul>

--- a/app/frontend/pages/Edicoes/Mostras.vue
+++ b/app/frontend/pages/Edicoes/Mostras.vue
@@ -12,11 +12,15 @@ defineProps({
     type: Array,
     required: true,
   },
+  fallBackUrl: {
+    type: String,
+    required: true,
+  },
 });
 </script>
 <template>
   <TwContainer>
-    <EdicaoHeader :edicao="edicao" />
+    <EdicaoHeader :edicao="edicao" :fallBackUrl="fallBackUrl" />
   </TwContainer>
   <MenuContext nav="edicoes_anteriores" active-page="Mostras" />
   <hr class="text-neutrals-300" />
@@ -27,7 +31,6 @@ defineProps({
           :class="`border-s-30 border-${categoria.class} rounded-lg overflow-hidden lg:h-[320px] h-[206px]`"
         >
           <figure class="relative m-0 h-full p-600 flex flex-col justify-end">
-            <!-- src="https://s3.amazonaws.com/festivaldorio/2024/site/peliculas/original/mals_f01cor_2024113147.jpg" -->
             <img
               class="absolute inset-0 w-full h-full object-cover -z-1"
               :src="categoria.mostraImageURL"

--- a/app/frontend/pages/Edicoes/Mostras.vue
+++ b/app/frontend/pages/Edicoes/Mostras.vue
@@ -1,0 +1,61 @@
+<script setup>
+import EdicaoHeader from "@/components/common/EdicaoHeader.vue";
+import MenuContext from "@/components/layout/navbar/MenuContext.vue";
+import TwContainer from "@/components/layout/TwContainer.vue";
+import { Link } from "@inertiajs/vue3";
+defineProps({
+  edicao: {
+    type: Object,
+    required: true,
+  },
+  categorias: {
+    type: Array,
+    required: true,
+  },
+});
+</script>
+<template>
+  <TwContainer>
+    <EdicaoHeader :edicao="edicao" />
+  </TwContainer>
+  <MenuContext nav="edicoes_anteriores" active-page="Mostras" />
+  <hr class="text-neutrals-300" />
+  <TwContainer>
+    <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 py-1200 gap-800">
+      <Link v-for="categoria in categorias" :href="categoria.path">
+        <li
+          :class="`border-s-30 border-${categoria.class} rounded-lg overflow-hidden lg:h-[320px] h-[206px]`"
+        >
+          <figure class="relative m-0 h-full p-600 flex flex-col justify-end">
+            <!-- src="https://s3.amazonaws.com/festivaldorio/2024/site/peliculas/original/mals_f01cor_2024113147.jpg" -->
+            <img
+              class="absolute inset-0 w-full h-full object-cover -z-1"
+              :src="categoria.mostraImageURL"
+              :alt="categoria.name"
+            />
+            <h1
+              class="text-white-transp-1000 mt-max text-header-regular-md z-1"
+            >
+              {{ categoria.name }}
+            </h1>
+          </figure>
+        </li>
+      </Link>
+    </ul>
+  </TwContainer>
+</template>
+<style scoped>
+figure::after {
+  position: absolute;
+  content: "";
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.3) 73.08%,
+    rgba(0, 0, 0, 0.64) 100%
+  );
+}
+</style>

--- a/app/models/edicao.rb
+++ b/app/models/edicao.rb
@@ -1,4 +1,6 @@
 class Edicao < ApplicationRecord
+  include Imageable
+
   CURRENT_ID = 13
 
   has_many :programacoes
@@ -7,6 +9,15 @@ class Edicao < ApplicationRecord
   has_many :peliculas
   has_many :importacao_convidados
   has_many :importacoesprogs, class_name: "Importacoesprog"
+
+  def image_path_prefix = "imagens/edicoes"
+  def image_default_size = "small"
+
+  def image_url(size = image_default_size)
+    return nil if cartaz.blank?
+
+    build_image_url(cartaz, size)
+  end
 
   def self.current
     Rails.cache.fetch("edicao/current/#{CURRENT_ID}", expires_in: 1.hour) do

--- a/app/models/edicao.rb
+++ b/app/models/edicao.rb
@@ -19,6 +19,10 @@ class Edicao < ApplicationRecord
     build_image_url(cartaz, size)
   end
 
+  def cartazURL(size = image_default_size)
+    image_url(size)
+  end
+
   def self.current
     Rails.cache.fetch("edicao/current/#{CURRENT_ID}", expires_in: 1.hour) do
       find(CURRENT_ID)

--- a/app/models/pelicula.rb
+++ b/app/models/pelicula.rb
@@ -108,7 +108,7 @@ class Pelicula < ApplicationRecord
     mostra.tag_class
   end
 
-  def image_path_prefix = "#{Edicao.current.descricao}/site/peliculas"
+  def image_path_prefix = "#{edicao.descricao}/site/peliculas"
   def image_default_size = "original"
 
   def imageURL(image_name = nil, size = "original")

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   # Regular plurals that end in 's'
   inflect.irregular "alteracao", "alteracoes"
   inflect.irregular "edicao", "edicoes"
+  inflect.irregular "edicao_anterior", "edicoes_anteriores"
   inflect.irregular "importacao", "importacoes"
   inflect.irregular "programacao", "programacoes"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,12 @@ Rails.application.routes.draw do
     resources :noticias, only: %i[ index show ], param: :permalink
     # other localized routes
 
-    resources :edicoes_anteriores, only: %i[ index ]
+    resources :edicoes_anteriores, only: [ :index ] do
+      resources :mostras, only: [ :index ], controller: "edicoes/mostras"
+      resources :filmes, only: [ :index ], controller: "edicoes/filmes"
+      resources :noticias, only: [ :index ], controller: "edicoes/noticias"
+      resources :juri, only: [ :index ], controller: "edicoes/juri", as: :juri
+    end
     resources :mostras, only: %i[ index show ], param: :category
     resources :peliculas, only: %i[ index show ], param: :permalink
     resources :cinemas, only: :index


### PR DESCRIPTION
## Summary

- Nova página `Edicoes/Mostras` lista mostras de uma edição anterior agrupadas por categoria, com cartaz da edição no header e link para `mostra_path`
- `EdicaoHeader` extraído como componente comum (botão voltar + descrição + cartaz com PhotoSwipe lightbox)
- `Cartaz` card refatorado de `<a>` para `<div>` para permitir reuso em contextos não-navegacionais
- `Edicao` model agora usa o concern `Imageable` (`image_path_prefix = "imagens/edicoes"`, override `image_url` para usar atributo `cartaz`)
- Fix em `Pelicula#image_path_prefix`: trocado `Edicao.current.descricao` por `edicao.descricao` para que peliculas de edições anteriores resolvam URLs do ano correto (ex: `2024/site/peliculas/...`)
- `MenuContext` ganhou suporte a `edicoes_anteriores` com itens Mostras/Notícias
- Novas rotas aninhadas sob `edicao_anterior`
- Novos icons `IconFilm` e `IconNewspaper`

## Context

Issue RIFF-52. Página de edições anteriores precisava expor a grade de mostras de cada ano. Bug derivado: imagens de peliculas de 2024 estavam tentando carregar do path da edição corrente — corrigido ao usar a associação `belongs_to :edicao` da própria pelicula.

URL de imagem do cartaz movida pro backend via `Imageable` para remover construção de URL hardcoded no frontend.

## Verification

- [ ] Tests pass locally
- [ ] Manually verified the changes
  - [ ] `/edicoes_anteriores/:id/mostras` renderiza categorias com imagem aleatória de pelicula daquela edição
  - [ ] Header mostra cartaz da edição; clique abre PhotoSwipe lightbox em tamanho natural
  - [ ] Botão "Voltar" funciona via `window.history.back()`
  - [ ] Imagens de peliculas resolvem para o ano correto (verificar 2024)

## Screenshots

<!-- adicionar screenshots da página Mostras e do lightbox do cartaz -->